### PR TITLE
feat(web): mass retranslate all novels in favorite list

### DIFF
--- a/web/src/pages/list/FavoriteList.vue
+++ b/web/src/pages/list/FavoriteList.vue
@@ -242,11 +242,14 @@ const queueOrderOptions = [
   { value: 'asc', label: '从旧到新' },
 ];
 
-const queueTaskSize = ref<'first5' | 'full' | 'full-expire'>('full');
+const queueTaskSize = ref<'first5' | 'full' | 'full-expire' | 'full-overwrite'>(
+  'full',
+);
 const queueTaskSizeOptions = [
   { value: 'first5', label: '前5话' },
   { value: 'full', label: '全部' },
-  { value: 'full-expire', label: '全部+过期章节' },
+  { value: 'full-expire', label: '全部并更新过期章节' },
+  { value: 'full-overwrite', label: '全部并覆盖所有章节' },
 ];
 
 const submitJob = (id: 'gpt' | 'sakura') => {
@@ -258,7 +261,12 @@ const submitJob = (id: 'gpt' | 'sakura') => {
       ? selectedNovels.novels
       : selectedNovels.novels.slice().reverse();
   const end = queueTaskSize.value === 'first5' ? 5 : 65535;
-  const level = queueTaskSize.value === 'full-expire' ? 'expire' : 'normal';
+  const level =
+    queueTaskSize.value === 'full-expire'
+      ? 'expire'
+      : queueTaskSize.value === 'full-overwrite'
+        ? 'all'
+        : 'normal';
 
   novelsSorted.forEach((it) => {
     const task = TranslateTaskDescriptor.web(it.providerId, it.novelId, {

--- a/web/src/pages/list/FavoriteList.vue
+++ b/web/src/pages/list/FavoriteList.vue
@@ -247,9 +247,9 @@ const queueTaskSize = ref<'first5' | 'full' | 'full-expire' | 'full-overwrite'>(
 );
 const queueTaskSizeOptions = [
   { value: 'first5', label: '前5话' },
-  { value: 'full', label: '全部' },
-  { value: 'full-expire', label: '全部并更新过期章节' },
-  { value: 'full-overwrite', label: '全部并覆盖所有章节' },
+  { value: 'full', label: '全文' },
+  { value: 'full-expire', label: '全文并更新过期章节' },
+  { value: 'full-overwrite', label: '全文并覆盖所有章节' },
 ];
 
 const submitJob = (id: 'gpt' | 'sakura') => {

--- a/web/src/pages/list/FavoriteList.vue
+++ b/web/src/pages/list/FavoriteList.vue
@@ -4,10 +4,11 @@ import {
   FormatListBulletedOutlined,
   PlusOutlined,
 } from '@vicons/material';
+import { useKeyModifier } from '@vueuse/core';
 import { MenuOption } from 'naive-ui';
 
-import { UserRepository } from '@/data/api';
 import { Locator } from '@/data';
+import { UserRepository } from '@/data/api';
 import { TranslateTaskDescriptor } from '@/model/Translator';
 import { FavoredList } from '@/model/User';
 import { WebNovelOutlineDto } from '@/model/WebNovel';
@@ -16,9 +17,9 @@ import { doAction, useIsWideScreen } from '@/pages/util';
 import { runCatching } from '@/util/result';
 
 import FavoriteMenuItem from './components/FavoriteMenuItem.vue';
-import { Loader } from './components/NovelPage.vue';
 import NovelListWeb from './components/NovelListWeb.vue';
 import NovelListWenku from './components/NovelListWenku.vue';
+import { Loader } from './components/NovelPage.vue';
 
 const props = defineProps<{
   page: number;
@@ -236,43 +237,25 @@ const moveToFavored = async () => {
   window.location.reload();
 };
 
-const queueOrder = ref<'asc' | 'desc'>('desc');
-const queueOrderOptions = [
-  { value: 'desc', label: '从新到旧' },
-  { value: 'asc', label: '从旧到新' },
-];
-
-const queueTaskSize = ref<'first5' | 'full' | 'full-expire' | 'full-overwrite'>(
-  'full',
-);
-const queueTaskSizeOptions = [
-  { value: 'first5', label: '前5话' },
-  { value: 'full', label: '全文' },
-  { value: 'full-expire', label: '全文并更新过期章节' },
-  { value: 'full-overwrite', label: '全文并覆盖所有章节' },
-];
+const translateLevel = ref<'normal' | 'expire' | 'all'>('normal');
+const forceMetadata = ref(false);
+const first5 = ref(false);
+const reverseOrder = ref(false);
+const shouldTopJob = useKeyModifier('Control');
 
 const submitJob = (id: 'gpt' | 'sakura') => {
   const selectedNovels = getSelectedNovels();
   if (selectedNovels === undefined || selectedNovels.type === 'wenku') return;
 
-  const novelsSorted =
-    queueOrder.value === 'desc'
-      ? selectedNovels.novels
-      : selectedNovels.novels.slice().reverse();
-  const end = queueTaskSize.value === 'first5' ? 5 : 65535;
-  const level =
-    queueTaskSize.value === 'full-expire'
-      ? 'expire'
-      : queueTaskSize.value === 'full-overwrite'
-        ? 'all'
-        : 'normal';
+  const novelsSorted = reverseOrder.value
+    ? selectedNovels.novels.slice().reverse()
+    : selectedNovels.novels;
 
   novelsSorted.forEach((it) => {
     const task = TranslateTaskDescriptor.web(it.providerId, it.novelId, {
       startIndex: 0,
-      endIndex: end,
-      level,
+      endIndex: first5.value ? 5 : 65535,
+      level: translateLevel.value,
       sync: false,
       forceMetadata: false,
     });
@@ -280,11 +263,15 @@ const submitJob = (id: 'gpt' | 'sakura') => {
       id === 'gpt'
         ? Locator.gptWorkspaceRepository()
         : Locator.sakuraWorkspaceRepository();
-    workspace.addJob({
+    const job = {
       task,
       description: it.titleJp,
       createAt: Date.now(),
-    });
+    };
+    workspace.addJob(job);
+    if (shouldTopJob.value) {
+      workspace.topJob(job);
+    }
   });
   message.success('排队成功');
 };
@@ -375,20 +362,49 @@ const submitJob = (id: 'gpt' | 'sakura') => {
             <n-flex vertical>
               <b>批量生成GPT/Sakura任务</b>
 
-              <c-action-wrapper title="顺序">
-                <c-radio-group
-                  v-model:value="queueOrder"
-                  :options="queueOrderOptions"
-                  size="small"
-                />
-              </c-action-wrapper>
+              <c-action-wrapper title="选项">
+                <n-flex size="small">
+                  <n-tooltip trigger="hover">
+                    <template #trigger>
+                      <n-flex :size="0" :wrap="false">
+                        <tag-button
+                          label="常规"
+                          :checked="translateLevel === 'normal'"
+                          @update:checked="translateLevel = 'normal'"
+                        />
+                        <tag-button
+                          label="过期"
+                          :checked="translateLevel === 'expire'"
+                          @update:checked="translateLevel = 'expire'"
+                        />
+                        <tag-button
+                          label="全部"
+                          type="warning"
+                          :checked="translateLevel === 'all'"
+                          @update:checked="translateLevel = 'all'"
+                        />
+                      </n-flex>
+                    </template>
+                    常规：只翻译未翻译的章节<br />
+                    过期：翻译术语表过期的章节<br />
+                    全部：翻译全部章节<br />
+                  </n-tooltip>
 
-              <c-action-wrapper title="范围">
-                <c-radio-group
-                  v-model:value="queueTaskSize"
-                  :options="queueTaskSizeOptions"
-                  size="small"
-                />
+                  <tag-button
+                    label="重翻目录"
+                    v-model:checked="forceMetadata"
+                  />
+                  <tag-button label="前5话" v-model:checked="first5" />
+                  <tag-button label="倒序添加" v-model:checked="reverseOrder" />
+
+                  <n-text
+                    v-if="translateLevel === 'all'"
+                    type="warning"
+                    style="font-size: 12px; flex-basis: 100%"
+                  >
+                    * 请谨慎使用“全部”选项
+                  </n-text>
+                </n-flex>
               </c-action-wrapper>
 
               <c-action-wrapper title="操作">

--- a/web/src/pages/other/AccountCenter.vue
+++ b/web/src/pages/other/AccountCenter.vue
@@ -61,7 +61,9 @@ const playSound = (source: string) => {
             <b>快捷键说明</b>
             <n-ul>
               <n-li>列表页面，可以使用左右方向键翻页。</n-li>
-              <n-li>小说页面，按住Ctrl键点击排队，会将任务自动置顶。</n-li>
+              <n-li>
+                GPT/Sakura排队按钮，按住Ctrl键点击，会将任务自动置顶。
+              </n-li>
               <n-li>阅读页面，可以使用左右方向键跳转上/下一章。</n-li>
               <n-li>阅读页面，可以使用数字键1～4快速切换翻译。</n-li>
             </n-ul>


### PR DESCRIPTION
加了一个可以一键把收藏里所有的小说文章都加入 Sakura 队列里并完全重翻的功能。

大概可能全村只有我一个人会用？因为我有 800 多篇小黄文，一个一个的点重翻太麻烦了。

![image](https://github.com/FishHawk/auto-novel/assets/47231500/1d3fe94c-2424-4123-9fc0-8216ea5ff5b5)

![image](https://github.com/FishHawk/auto-novel/assets/47231500/5c6debfe-e9ef-43c7-9a5b-2dcfbab20fb3)

UI 方面鱼鹰大大你可以看看要不要改一下。因为原本的 `全部+过期章节` 我一直感觉有点看不太懂是什么意思，所以改成了字多一点的解释。如果缩短一些更好可以随意修改。