### PR TITLE
fix(web): prevent default behavior on mouse down event in CXScrollbar.vue

### DIFF
--- a/web/src/pages/components/CXScrollbar.vue
+++ b/web/src/pages/components/CXScrollbar.vue
@@ -4,6 +4,7 @@ import { ScrollbarInst } from 'naive-ui';
 const scrollRef = ref<ScrollbarInst>();
 let point = { x: 0, isDrag: false };
 const handleMouseDown = (e: MouseEvent) => {
+  e.preventDefault();
   point.x = e.clientX;
   point.isDrag = false;
 


### PR DESCRIPTION
文库页面的各卷封面用到了x-scrollbar，图片上拖拽会引发图片拖拽行为导致x-scrollbar拖拽异常