### PR TITLE
fix(web): keep-alive component in nested route result in child route mounted twice

### DIFF
--- a/web/src/pages/layouts/ReaderLayout.vue
+++ b/web/src/pages/layouts/ReaderLayout.vue
@@ -1,5 +1,5 @@
 <template>
   <n-layout style="width: 100%; min-height: 100vh">
-    <router-view />
+    <router-view name="reader" />
   </n-layout>
 </template>

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -45,7 +45,6 @@ const router = createRouter({
           components: {
             reader: () => import('./pages/reader/Reader.vue'),
           },
-          name: 'reader',
         },
         {
           path: '/workspace/reader/:novelId/:chapterId',

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -42,11 +42,16 @@ const router = createRouter({
       children: [
         {
           path: '/novel/:providerId/:novelId/:chapterId',
-          component: () => import('./pages/reader/Reader.vue'),
+          components: {
+            reader: () => import('./pages/reader/Reader.vue'),
+          },
+          name: 'reader',
         },
         {
           path: '/workspace/reader/:novelId/:chapterId',
-          component: () => import('./pages/reader/Reader.vue'),
+          components: {
+            reader: () => import('./pages/reader/Reader.vue'),
+          },
         },
       ],
     },


### PR DESCRIPTION
这里使用的是 [嵌套命名路由](https://router.vuejs.org/zh/guide/essentials/named-views.html#%E5%B5%8C%E5%A5%97%E5%91%BD%E5%90%8D%E8%A7%86%E5%9B%BE) 来处理

相关Issues 
- https://github.com/vuejs/router/issues/626#issuecomment-1751747077

![a85d41d8b652f00aecdeb80789891f0e](https://github.com/FishHawk/auto-novel/assets/32838658/a0757477-b7b1-40a4-accc-cf14452824ec)


