### PR TITLE
对于有重叠部分的术语，防止更新较短的术语时，重翻长术语的段落。

### DIFF
--- a/web/src/pages/bookshelf/components/BookshelfLocalControl.vue
+++ b/web/src/pages/bookshelf/components/BookshelfLocalControl.vue
@@ -188,7 +188,8 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
     </n-list-item>
 
     <n-list-item v-if="favoreds.local.length > 1">
-      <n-flex vertical>
+      <n-p>移动小说功能暂时关闭</n-p>
+      <n-flex v-if="false" vertical>
         <b>移动小说</b>
 
         <n-radio-group v-model:value="targetFavoredId">

--- a/web/src/pages/bookshelf/components/BookshelfWebControl.vue
+++ b/web/src/pages/bookshelf/components/BookshelfWebControl.vue
@@ -179,7 +179,8 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
     </n-list-item>
 
     <n-list-item v-if="favoreds.web.length > 1">
-      <n-flex vertical>
+      <n-p>移动小说功能暂时关闭</n-p>
+      <n-flex v-if="false" vertical>
         <b>移动小说（低配版，很慢，等到显示移动完成）</b>
 
         <n-radio-group v-model:value="targetFavoredId">

--- a/web/src/pages/bookshelf/components/BookshelfWenkuControl.vue
+++ b/web/src/pages/bookshelf/components/BookshelfWenkuControl.vue
@@ -123,7 +123,8 @@ const moveToFavored = async () => {
     </n-list-item>
 
     <n-list-item v-if="favoreds.wenku.length > 1">
-      <n-flex vertical>
+      <n-p>移动小说功能暂时关闭</n-p>
+      <n-flex v-if="false" vertical>
         <b>移动小说（低配版，很慢，等到显示移动完成）</b>
 
         <n-radio-group v-model:value="targetFavoredId">


### PR DESCRIPTION
从长到短查找单词。查到后，将段落split为多个，多个段落中不存在这个单词。之后再在多个段落中查找较短的单词。防止重翻时，如果更新的是短术语，而长术语中又恰好包含这个短术语，则避免重翻只包含那个长术语而不包含短术语的段落。

例子：对于这个段落，同时存在 ディー 和 ディーゼル 的术语。
[jp.幽鬼test.txt](https://github.com/user-attachments/files/16179714/jp.test.txt)


<table>
  <tr>
    <th>修改前分段术语表检测</th>
    <th>修改后的分段术语表检测</th>
  </tr>
  <tr>
    <td>
      <pre>
获取未翻译章节 jp.幽鬼test.txt

[0] jp.幽鬼test.txt/0 
　segGlossary:{} 
　分段1/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔",
  "ディー": "迪"
} 
　分段2/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔",
  "ディー": "迪"
} 
　分段3/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔",
  "ディー": "迪"
} 
　分段4/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔",
  "ディー": "迪"
} 
　分段5/8　从缓存恢复 
　segGlossary:{} 
　分段6/8　从缓存恢复 
　segGlossary:{
  "ディー": "迪"
} 
　分段7/8　从缓存恢复 
　segGlossary:{
  "ディー": "迪"
} 
　分段8/8　从缓存恢复 
上传章节 

结束</pre>
 </td>
 <td>
<pre>
获取未翻译章节 jp.幽鬼test.txt 

[0] jp.幽鬼test.txt/0 
　segGlossary:{} 
　分段1/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔"
} 
　分段2/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔"
} 
　分段3/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔"
} 
　分段4/8　从缓存恢复 
　segGlossary:{
  "ディーゼル": "迪赛尔"
} 
　分段5/8　从缓存恢复 
　segGlossary:{} 
　分段6/8　从缓存恢复 
　segGlossary:{
  "ディー": "迪"
} 
　分段7/8　从缓存恢复 
　segGlossary:{
  "ディー": "迪"
} 
　分段8/8　从缓存恢复 
上传章节 

结束 
      </pre>
    </td>
  </tr>
</table>


可以看到，修改后的仅存在ディーゼル的分段中不会检测到ディー，这样重翻的时候，如果修改了ディー，则仅存在ディーゼル而不存在单独的ディー的分段不受到影响。