### PR TITLE
feat(web): enable editing for katakanaTranslations in table view

### DIFF
--- a/web/src/pages/components/GlossaryButton.vue
+++ b/web/src/pages/components/GlossaryButton.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   gnid?: GenericNovelId;
   value: Glossary;
 }>();
-const isEditable = ref(false);
+
 const message = useMessage();
 
 const glossary = ref<Glossary>({});
@@ -226,33 +226,21 @@ const importGlossary = () => {
         </td>
         <td>{{ wordJp }}</td>
         <td nowrap="nowrap">=></td>
-        <td>
-          <input
-            v-model="glossary[wordJp]"
-            :readonly="!isEditable"
-            style="
-              border: none;
-              outline: none;
-              background-color: transparent;
-              width: auto;
-            "
+        <td style="padding-right: 16px">
+          <n-input
+            v-model:value="glossary[wordJp]"
+            size="tiny"
+            placeholder="请输入中文翻译"
+            :theme-overrides="{
+              border: '0',
+              color: 'transprent',
+            }"
           />
         </td>
       </tr>
     </n-table>
 
     <template #action>
-      <div style="margin-right: auto">
-        <n-space>
-          <span>编辑模式</span>
-          <n-tooltip trigger="hover">
-            <template #trigger>
-              <n-switch v-model:value="isEditable" />
-            </template>
-            使翻译后的术语表可编辑
-          </n-tooltip>
-        </n-space>
-      </div>
       <c-button label="提交" type="primary" @action="submitGlossary()" />
     </template>
   </c-modal>

--- a/web/src/pages/components/GlossaryButton.vue
+++ b/web/src/pages/components/GlossaryButton.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   gnid?: GenericNovelId;
   value: Glossary;
 }>();
-
+const isEditable = ref(false);
 const message = useMessage();
 
 const glossary = ref<Glossary>({});
@@ -226,11 +226,33 @@ const importGlossary = () => {
         </td>
         <td>{{ wordJp }}</td>
         <td nowrap="nowrap">=></td>
-        <td>{{ glossary[wordJp] }}</td>
+        <td>
+          <input
+            v-model="glossary[wordJp]"
+            :readonly="!isEditable"
+            style="
+              border: none;
+              outline: none;
+              background-color: transparent;
+              width: auto;
+            "
+          />
+        </td>
       </tr>
     </n-table>
 
     <template #action>
+      <div style="margin-right: auto">
+        <n-space>
+          <span>编辑模式</span>
+          <n-tooltip trigger="hover">
+            <template #trigger>
+              <n-switch v-model:value="isEditable" />
+            </template>
+            使翻译后的术语表可编辑
+          </n-tooltip>
+        </n-space>
+      </div>
       <c-button label="提交" type="primary" @action="submitGlossary()" />
     </template>
   </c-modal>

--- a/web/src/pages/workspace/Katakana.vue
+++ b/web/src/pages/workspace/Katakana.vue
@@ -285,12 +285,17 @@ const showListModal = ref(false);
             <td nowrap="nowrap">=></td>
             <td>
               {{ number }}
-              <n-text
-                v-if="katakanaTranslations[word]"
-                style="margin-left: 16px"
-              >
-                {{ katakanaTranslations[word] }}
-              </n-text>
+              <input
+                v-if="katakanaTranslations[word] !== undefined"
+                v-model="katakanaTranslations[word]"
+                style="
+                  margin-left: 16px;
+                  border: none;
+                  outline: none;
+                  background-color: transparent;
+                  width: auto;
+                "
+              />
             </td>
           </tr>
         </n-table>

--- a/web/src/pages/workspace/Katakana.vue
+++ b/web/src/pages/workspace/Katakana.vue
@@ -9,7 +9,7 @@ import { useIsWideScreen } from '@/pages/util';
 import { Epub, Txt } from '@/util/file';
 
 import LoadedVolume from './components/LoadedVolume.vue';
-const isEditable = ref(false)
+const isEditable = ref(false);
 const message = useMessage();
 const isWideScreen = useIsWideScreen();
 const sakuraWorkspace = Locator.sakuraWorkspaceRepository().ref;
@@ -270,7 +270,7 @@ const showListModal = ref(false);
           </n-button-group>
         </n-flex>
       </c-action-wrapper>
-      <c-action-wrapper title="編輯模式">
+      <c-action-wrapper title="编辑模式">
         <n-space>
           <n-tooltip trigger="hover">
             <template #trigger>

--- a/web/src/pages/workspace/Katakana.vue
+++ b/web/src/pages/workspace/Katakana.vue
@@ -9,7 +9,7 @@ import { useIsWideScreen } from '@/pages/util';
 import { Epub, Txt } from '@/util/file';
 
 import LoadedVolume from './components/LoadedVolume.vue';
-
+const isEditable = ref(false)
 const message = useMessage();
 const isWideScreen = useIsWideScreen();
 const sakuraWorkspace = Locator.sakuraWorkspaceRepository().ref;
@@ -270,6 +270,16 @@ const showListModal = ref(false);
           </n-button-group>
         </n-flex>
       </c-action-wrapper>
+      <c-action-wrapper title="編輯模式">
+        <n-space>
+          <n-tooltip trigger="hover">
+            <template #trigger>
+              <n-switch v-model:value="isEditable" />
+            </template>
+            使翻译后的术语表可编辑
+          </n-tooltip>
+        </n-space>
+      </c-action-wrapper>
     </n-flex>
 
     <n-divider />
@@ -288,6 +298,7 @@ const showListModal = ref(false);
               <input
                 v-if="katakanaTranslations[word] !== undefined"
                 v-model="katakanaTranslations[word]"
+                :readonly="!isEditable"
                 style="
                   margin-left: 16px;
                   border: none;


### PR DESCRIPTION
### 術語表工作區 & 術語表按鈕
增加術語表編輯效率
術語表工作區：執行翻譯後可直接編輯翻譯結果
術語表按鈕：可直接編輯導入的術語表中文
加入n-switch，可開關編輯模式