### PR TITLE
feat(local): 优化本地工作区的体验。（顺便把GPT的key重复限制从错误改成仅警告）

### DIFF
--- a/web/src/pages/novel/components/TranslateOptions.vue
+++ b/web/src/pages/novel/components/TranslateOptions.vue
@@ -8,7 +8,7 @@ import { Glossary } from '@/model/Glossary';
 import { TranslateTaskParams } from '@/model/Translator';
 import { useIsWideScreen } from '@/pages/util';
 
-defineProps<{
+const probs = defineProps<{
   gnid: GenericNovelId;
   glossary: Glossary;
 }>();
@@ -17,7 +17,9 @@ const isWideScreen = useIsWideScreen(600);
 const { setting } = Locator.settingRepository();
 
 // 翻译设置
-const translateLevel = ref<'normal' | 'expire' | 'all' | 'sync'>('normal');
+const translateLevel = ref<'normal' | 'expire' | 'all' | 'sync'>(
+  probs.gnid.type === 'local' ? 'expire' : 'normal',
+);
 const forceMetadata = ref(false);
 const startIndex = ref<number | null>(0);
 const endIndex = ref<number | null>(65536);
@@ -92,7 +94,10 @@ const showDownloadModal = ref(false);
       </n-flex>
     </c-action-wrapper>
 
-    <c-action-wrapper v-if="gnid.type === 'web'" title="范围">
+    <c-action-wrapper
+      v-if="gnid.type === 'web' || gnid.type === 'local'"
+      title="范围"
+    >
       <n-flex style="text-align: center">
         <div>
           <n-input-group>
@@ -123,7 +128,7 @@ const showDownloadModal = ref(false);
               v-model:value="taskNumber"
               :show-button="false"
               :min="1"
-              :max="10"
+              :max="gnid.type === 'local' ? 65536 : 10"
               style="width: 40px"
             />
             <n-input-group-label size="small">个任务</n-input-group-label>
@@ -141,7 +146,7 @@ const showDownloadModal = ref(false);
       </n-flex>
     </c-action-wrapper>
 
-    <c-action-wrapper title="操作">
+    <c-action-wrapper v-if="gnid.type !== 'local'" title="操作">
       <n-button-group size="small">
         <c-button
           label="下载设置"

--- a/web/src/pages/workspace/components/GptWorkerModal.vue
+++ b/web/src/pages/workspace/components/GptWorkerModal.vue
@@ -81,11 +81,12 @@ const formRules: FormRules = {
   key: [
     emptyCheck('Key'),
     {
+      level: 'warning',
       validator: (rule: FormItemRule, value: string) =>
         workspaceRef.value.workers
           .filter(({ id }) => id !== props.worker?.id)
           .find(({ key }) => key === value) === undefined,
-      message: 'Key不能重复',
+      message: '有重复的Key (仅作为不支持并发的api的提醒)',
       trigger: 'input',
     },
   ],


### PR DESCRIPTION
* 让本地翻译可以指定startIndex, endIndex 和 taskNumber。还有翻译的类型。

* 在本地翻译的UI的“本地小说”的上方上增加了“本地翻译设置”，可以设置**翻译的类型**（默认设置为了 expired）和**翻译的范围**（将 本地翻译的taskNumber的上限取消了）。

（或许本地翻译设置可折叠会好看一些？）

* 本地翻译过期章节时，可以不完全重翻过期章节，而是只翻译术语表影响的段落。

* 创建GPT翻译器时，让Key可重复，仅显示一个警告提醒。因为对于支持多并发的api，key是可以重复的。（名字重复应该也没啥问题但我没动（））