### PR TITLE
feat(web): override linkify-it regex to exclude Chinese characters from URLs

### DIFF
--- a/web/src/pages/components/Markdown.vue
+++ b/web/src/pages/components/Markdown.vue
@@ -8,6 +8,19 @@ const md = new MarkdownIt({
   breaks: true,
   linkify: true,
 }).use(MarkdownItAnchor);
+
+md.linkify.add('http:', {
+  validate: function (text, pos, self) {
+    const tail = text.slice(pos);
+    if (!self.re.customHTTP) {
+      self.re.customHTTP =
+        /(\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(?:[/?][a-zA-Z0-9-_/?=&%*#+]+)?)/g;
+    }
+
+    return tail.match(self.re.customHTTP)?.[0].length || 0;
+  },
+});
+
 const vars = useThemeVars();
 </script>
 


### PR DESCRIPTION
避免中文识别到链接里

这里使用的规则与评论区里的链接识别规则相同

示例文章
> https://books.fishhawk.top/forum/672bc2c2dcc937185eb631e8
