### PR TITLE
feat(web): 延长请求超时设置

### DIFF
--- a/web/src/data/api/client.ts
+++ b/web/src/data/api/client.ts
@@ -1,6 +1,6 @@
 import ky from 'ky';
 
-let client = ky.create({ prefixUrl: window.origin + '/api' });
+let client = ky.create({ prefixUrl: '/api', timeout: 60000 });
 let authToken: string | undefined = undefined;
 
 export { client };


### PR DESCRIPTION
默认超时10s在网络或服务卡的情况下发送文章/评论会失败，但是数据可能已经入库了。用户如果重发文章/评论，会出现重复数据