### PR TITLE
web: The concurrent translation function has been added, and the maxi…

### DIFF
--- a/web/src/domain/translate/Common.ts
+++ b/web/src/domain/translate/Common.ts
@@ -13,6 +13,8 @@ export type Segmentor = (
 export type Logger = (message: string, detail?: string[]) => void;
 
 export type SegmentContext = {
+  chapterId?: number; // 新增：章节序号
+  sectionId?: number; // 新增：分段序号
   glossary: Glossary;
   prevSegs: string[][];
   signal?: AbortSignal;

--- a/web/src/domain/translate/Semaphore.ts
+++ b/web/src/domain/translate/Semaphore.ts
@@ -1,0 +1,65 @@
+export class Semaphore {
+  private tasks: Array<() => void> = [];
+  private currentCount: number = 0;
+
+  constructor(private maxConcurrency: number) {}
+
+  acquire(signal?: AbortSignal): Promise<() => void> {
+    return new Promise((resolve, reject) => {
+      const task = () => {
+        if (signal?.aborted) {
+          reject(new Error('翻译任务已被取消'));
+          return;
+        }
+        this.currentCount++;
+        const release = () => {
+          this.currentCount--;
+          if (this.tasks.length > 0) {
+            const nextTask = this.tasks.shift();
+            if (nextTask) nextTask();
+          }
+        };
+        resolve(release);
+      };
+
+      if (signal?.aborted) {
+        reject(new Error('翻译任务已被取消'));
+        return;
+      }
+
+      const wrappedTask = () => {
+        task();
+      };
+
+      if (this.currentCount < this.maxConcurrency) {
+        wrappedTask();
+      } else {
+        this.tasks.push(wrappedTask);
+        if (signal) {
+          const onAbort = () => {
+            const index = this.tasks.indexOf(wrappedTask);
+            if (index > -1) {
+              this.tasks.splice(index, 1);
+              reject(new Error('翻译任务已被取消'));
+            }
+          };
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+    });
+  }
+}
+
+// 设置您的最大并发量
+var MAX_CONCURRENCY = 1;
+// 修改MAX_CONCURRENC 的函数
+export function setMaxConcurrency(maxConcurrency: number) {
+  MAX_CONCURRENCY = maxConcurrency;
+}
+
+// 单例信号量实例
+export var globalSemaphore = new Semaphore(MAX_CONCURRENCY);
+// 单例信号量实例的函数
+export function setGlobalSemaphore() {
+  globalSemaphore = new Semaphore(MAX_CONCURRENCY);
+}

--- a/web/src/domain/translate/TranslatorOpenAi.ts
+++ b/web/src/domain/translate/TranslatorOpenAi.ts
@@ -37,10 +37,9 @@ export class OpenAiTranslator implements SegmentTranslator {
 
   async translate(
     seg: string[],
-    { glossary, signal }: SegmentContext,
+    { chapterId, sectionId, glossary, signal }: SegmentContext, // 新增：接收章节序号和分段序号
   ): Promise<string[]> {
     let enableBypass = false;
-
     const logSegInfo = ({
       retry,
       binaryRange,
@@ -54,7 +53,15 @@ export class OpenAiTranslator implements SegmentTranslator {
     }) => {
       const parts: string[] = [];
       if (retry !== undefined) {
-        parts.push(`第${retry + 1}次`);
+        var chapterString = '';
+        if (chapterId !== undefined) {
+          chapterString = `章节${chapterId}-`; // 新增：打印章节序
+        }
+        var sectionString = '';
+        if (sectionId !== undefined) {
+          sectionString += `分段${sectionId}\t`; // 新增：打印分段序号
+        }
+        parts.push(`${chapterString}${sectionString}第${retry + 1}次`); // 更改：打印章节序号和分段序号
       }
       if (binaryRange !== undefined) {
         const [left, right] = binaryRange;

--- a/web/src/domain/translate/TranslatorSakura.ts
+++ b/web/src/domain/translate/TranslatorSakura.ts
@@ -84,7 +84,7 @@ export class SakuraTranslator implements SegmentTranslator {
 
   async translate(
     seg: string[],
-    { glossary, prevSegs, signal }: SegmentContext,
+    { chapterId, sectionId, glossary, prevSegs, signal }: SegmentContext,
   ): Promise<string[]> {
     const concatedSeg = seg.join('\n');
     const prevSegCount = -Math.ceil(this.prevSegLength / this.segLength);
@@ -103,8 +103,15 @@ export class SakuraTranslator implements SegmentTranslator {
         retry > 1,
       );
       const splitText = text.replaceAll('<|im_end|>', '').split('\n');
-
-      const parts: string[] = [`第${retry}次`];
+      var chapterString = '';
+      if (chapterId !== undefined) {
+        chapterString = `章节${chapterId}-`; // 新增：打印章节序
+      }
+      var sectionString = '';
+      if (sectionId !== undefined) {
+        sectionString += `分段${sectionId}\t`; // 新增：打印分段序号
+      }
+      const parts: string[] = [`${chapterString}${sectionString}第${retry}次`]; // 更改：打印章节序号和分段序号
       const linesNotMatched = seg.length !== splitText.length;
       if (hasDegradation) {
         parts.push('退化');

--- a/web/src/pages/novel/components/TranslateOptions.vue
+++ b/web/src/pages/novel/components/TranslateOptions.vue
@@ -7,7 +7,8 @@ import { GenericNovelId } from '@/model/Common';
 import { Glossary } from '@/model/Glossary';
 import { TranslateTaskParams } from '@/model/Translator';
 import { useIsWideScreen } from '@/pages/util';
-
+import { ref, watch } from 'vue';
+import { setMaxConcurrency } from '@/domain/translate/Semaphore';
 const probs = defineProps<{
   gnid: GenericNovelId;
   glossary: Glossary;
@@ -24,6 +25,17 @@ const forceMetadata = ref(false);
 const startIndex = ref<number | null>(0);
 const endIndex = ref<number | null>(65536);
 const taskNumber = ref<number | null>(1);
+const maxConcurrency = ref<number | null>(1);
+
+watch(maxConcurrency, (newVal, oldVal) => {
+  // 检查输入是否为有效数字
+  if (newVal === null || isNaN(newVal)) {
+    setMaxConcurrency(1);
+  } else {
+    console.log(`输入值从 ${oldVal} 变为 ${newVal}`);
+    setMaxConcurrency(newVal);
+  }
+});
 
 defineExpose({
   getTranslateTaskParams: (): TranslateTaskParams => ({
@@ -120,6 +132,30 @@ const showDownloadModal = ref(false);
             />
           </n-input-group>
         </div>
+
+        <div>
+          <n-input-group>
+            <n-input-group-label size="small">并发</n-input-group-label>
+            <n-input-number
+              size="small"
+              v-model:value="maxConcurrency"
+              :show-button="false"
+              :min="1"
+              :max="gnid.type === 'local' ? 65536 : 10"
+              style="width: 40px"
+            />
+            <n-input-group-label size="small">条请求</n-input-group-label>
+          </n-input-group>
+        </div>
+        <n-tooltip trigger="hover" placement="top" style="max-width: 200px">
+          <template #trigger>
+            <n-button text>
+              <n-icon depth="4" :component="InfoOutlined" />
+            </n-button>
+          </template>
+          最大并发量应在自己的API的允许范围内设置。
+        </n-tooltip>
+
         <div>
           <n-input-group>
             <n-input-group-label size="small">均分</n-input-group-label>

--- a/web/src/pages/workspace/components/JobWorker.vue
+++ b/web/src/pages/workspace/components/JobWorker.vue
@@ -18,6 +18,7 @@ import {
   TranslateTaskDescriptor,
 } from '@/model/Translator';
 import TranslateTask from '@/pages/components/TranslateTask.vue';
+import { setGlobalSemaphore } from '@/domain/translate/Semaphore';
 
 const props = defineProps<{
   worker:
@@ -86,6 +87,7 @@ const running = computed(() => currentJob.value !== undefined);
 let abortHandler = () => {};
 
 const processTasks = async () => {
+  setGlobalSemaphore(); // 限制并发数
   const controller = new AbortController();
   const { signal } = controller;
   abortHandler = () => controller.abort();

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -38,6 +38,8 @@ export default defineConfig(({ command, mode }) => {
   return {
     server: {
       proxy,
+      port: 3000, // 在这里设置您想要的端口号，例如 3000
+      host: '127.0.0.1', // 可选：强制使用 IPv4
     },
     build: {
       target: ['es2015', 'edge88', 'firefox78', 'chrome87', 'safari14'],


### PR DESCRIPTION
增加了并发翻译功能，并且可以设置最大并发量（此功能可以极大提高翻译速度）
由于翻译log在翻译过程中只会显示第几次翻译，因此在前面加上了章节序号和分段序号
由于是并发翻译，所以翻译log的输出会比较乱
目前有个两小bug：
1 是停止后想要重新翻译只能刷新页面
2 是刷新页面后的并发量虽然默认显示1，但其实是之前翻译的并发，需要重新把值修改一次（这样监视器才会识别到值的修改）

翻译过程截图
![Quicker_20241221_151420](https://github.com/user-attachments/assets/eacedd4d-6e4d-4602-b179-3f56b470784f)
![Quicker_20241221_152234](https://github.com/user-attachments/assets/e3403c18-61af-4e53-97ed-19e8d2f1569c)
![Quicker_20241221_151432](https://github.com/user-attachments/assets/08ad2cfe-ac88-4afa-bad8-b506d19debca)
（图中的失败是并发的api的余额不足(Insufficient Balance)导致的，不是代码的问题）

以下是修改的文件
web
	src
		domain
			translate
				Common.ts --在 SegmentContext 新增章节序号和分段序号
				TranslateLocal.ts --修改为对章节的并发翻译(同时在翻译停止时关闭所有并发)，同时向下传递章节序号
				Translator.ts --修改为对分段的并发翻译(同时限制并发量)，同时向下传递章节序号和分段序号
				TranslatorOpenAi.ts --在 translate 打印章节序号和分段序号
				TranslatorSakura.ts --在 translate 打印章节序号和分段序号
				Semaphore.ts --并发限制的锁(最大并发量在此处修改)，及修改并发量和创建锁的函数
		pages
			novel
				components
					TranslateOptions.vue --增加调节最大并发量的控件及对其的监视器
			workspace
				components
					JobWorker.vue --在启动时根据之前调节的最大并发量，创建并发限制的锁
	vite.config.ts --在 server 新增对 host 和 port 的指定（我这边默认端口使用不了才加的）