### PR TITLE
feat(web): 更新`epub/txt转换` 工作区，可以将 Epub转化为Txt。

### DIFF
--- a/web/src/pages/layouts/MainLayout.vue
+++ b/web/src/pages/layouts/MainLayout.vue
@@ -145,6 +145,10 @@ const menuOptions = computed<MenuOption[]>(() => {
           label: renderLabel('OCR修复', '/workspace/ocr-fix'),
           key: '/workspace/ocr-fix',
         },
+        {
+          label: renderLabel('EPUB/TXT转换', '/workspace/epub-txt-converter'),
+          key: '/workspace/epub-txt-converter',
+        },
       ],
     },
     {

--- a/web/src/pages/workspace/EpubTxtConverter.vue
+++ b/web/src/pages/workspace/EpubTxtConverter.vue
@@ -44,7 +44,7 @@ const customRequest = ({
 
 const downloadTxt = async (volume: LoadedVolume) => {
   downloadFile(
-    volume.filename.replace('.epub', '.txt'),
+    volume.filename.replace(/\.epub$/, '.txt'),
     new Blob([volume.content], { type: 'text/plain' }),
   );
 };

--- a/web/src/pages/workspace/EpubTxtConverter.vue
+++ b/web/src/pages/workspace/EpubTxtConverter.vue
@@ -1,0 +1,86 @@
+<script lang="ts" setup>
+import { downloadFile } from '@/util';
+import { getFullContent } from '@/util/file';
+import { DriveFolderUploadOutlined } from '@vicons/material';
+import { UploadCustomRequestOptions } from 'naive-ui';
+
+const message = useMessage();
+
+interface LoadedVolume {
+  filename: string;
+  content: string;
+}
+
+const loadedVolumes = ref<LoadedVolume[]>([]);
+
+const loadVolume = async (filename: string, file: File) => {
+  if (
+    loadedVolumes.value.find((it) => it.filename === filename) !== undefined
+  ) {
+    message.warning('文件已经载入');
+    return;
+  }
+
+  const content = await getFullContent(file);
+  loadedVolumes.value.push({
+    filename,
+    content,
+  });
+};
+
+const customRequest = ({
+  file,
+  onFinish,
+  onError,
+}: UploadCustomRequestOptions) => {
+  if (!file.file) return;
+  loadVolume(file.name, file.file)
+    .then(onFinish)
+    .catch((err) => {
+      message.error('文件载入失败:' + err);
+      onError();
+    });
+};
+
+const downloadTxt = async (volume: LoadedVolume) => {
+  downloadFile(
+    volume.filename.replace('.epub', '.txt'),
+    new Blob([volume.content], { type: 'text/plain' }),
+  );
+};
+</script>
+
+<template>
+  <div class="layout-content">
+    <n-h1>EPUB/TXT转换</n-h1>
+
+    <bulletin>
+      <n-p> 该工具支持将 EPUB 文件提取为 TXT 文本。 </n-p>
+      <n-p> 请上传 EPUB 文件并点击对应按钮下载提取的文本内容。 </n-p>
+    </bulletin>
+
+    <n-flex vertical>
+      <n-upload
+        :show-file-list="false"
+        accept=".epub"
+        multiple
+        directory-dnd
+        :custom-request="customRequest"
+      >
+        <n-upload-dragger style="margin: 16px 0">
+          <n-icon size="32" :component="DriveFolderUploadOutlined" />
+          <div>拖拽 EPUB 文件到这里提取文本</div>
+        </n-upload-dragger>
+      </n-upload>
+
+      <n-flex vertical>
+        <div v-for="volume in loadedVolumes" :key="volume.filename">
+          <n-button type="success" text @click="downloadTxt(volume)">
+            [下载提取后的TXT]
+            {{ volume.filename }}
+          </n-button>
+        </div>
+      </n-flex>
+    </n-flex>
+  </div>
+</template>

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -216,6 +216,11 @@ const router = createRouter({
               meta: { title: 'OCR修复' },
               component: () => import('./pages/workspace/OcrFix.vue'),
             },
+            {
+              path: 'epub-txt-converter',
+              meta: { title: 'EPUB/TXT转换' },
+              component: () => import('./pages/workspace/EpubTxtConverter.vue'),
+            },
           ],
         },
 


### PR DESCRIPTION
增加 `epub/txt转换` 工作区，可以将 Epub转化为Txt。

目前的epub文本的提取方式是使用仓库里现成的 `getFullContent` 函数（直接将xhtml内的所有文本提取，并去除rt标签）。
如果需要优化提取方式，可以讲讲怎么弄。

在win11的Edge和华为浏览器上测试过，没问题。

未来可能会尝试在这个工作区增加txt转epub功能（可选择载入多个翻译文本，交替显示，目录通过正则或者章节名的数组自动生成，自定义每个翻译源的样式和名字/作者/封面，然后生成对应epub）