### PR TITLE
fix(web): 修复 markdown 编辑器切换预览后输入框丢失了编辑历史

### DIFF
--- a/web/src/pages/components/markdown/MarkdownEditor.vue
+++ b/web/src/pages/components/markdown/MarkdownEditor.vue
@@ -67,7 +67,7 @@ const elEditor = useTemplateRef('editor');
           @clear-draft="clearDraft"
         />
       </template>
-      <n-tab-pane tab="编辑" :name="0">
+      <n-tab-pane tab="编辑" :name="0" display-directive="show">
         <n-flex
           v-if="!isWideScreen"
           :size="0"


### PR DESCRIPTION
fix #158