### PR TITLE
fix(web): 修复iOS设备滑动穿透，n-scrollbar滚动条不显示的问题

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -103,9 +103,6 @@ if (RegexUtil.isSafari(navigator.userAgent)) {
 </template>
 
 <style>
-body {
-  overflow-y: scroll;
-}
 a {
   text-decoration: none;
 }
@@ -134,5 +131,25 @@ li {
 }
 .sortable-ghost {
   opacity: 0.7;
+}
+
+@supports (-webkit-touch-callout: none) {
+  /* 仅在支持 -webkit-touch-callout 的设备上生效（iOS 特有） */
+
+  .v-vl:not(.v-vl--show-scrollbar),
+  .n-scrollbar > .n-scrollbar-container {
+    scrollbar-width: unset;
+  }
+
+  .v-vl:not(.v-vl--show-scrollbar)::-webkit-scrollbar,
+  .v-vl:not(.v-vl--show-scrollbar)::-webkit-scrollbar-track-piece,
+  .v-vl:not(.v-vl--show-scrollbar)::-webkit-scrollbar-thumb,
+  .n-scrollbar > .n-scrollbar-container::-webkit-scrollbar,
+  .n-scrollbar > .n-scrollbar-container::-webkit-scrollbar-track-piece,
+  .n-scrollbar > .n-scrollbar-container::-webkit-scrollbar-thumb {
+    width: unset;
+    height: unset;
+    display: unset;
+  }
 }
 </style>

--- a/web/src/components/CDrawerLeft.vue
+++ b/web/src/components/CDrawerLeft.vue
@@ -1,10 +1,5 @@
 <template>
-  <n-drawer
-    :width="280"
-    :auto-focus="false"
-    :block-scroll="false"
-    placement="left"
-  >
+  <n-drawer :width="280" :auto-focus="false" placement="left">
     <n-drawer-content
       :native-scrollbar="false"
       :scrollbar-props="{ trigger: 'none' }"

--- a/web/src/components/CDrawerRight.vue
+++ b/web/src/components/CDrawerRight.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useWindowSize } from '@vueuse/core';
 
-defineProps<{ title: string }>();
+defineProps<{ title: string; disableScroll?: boolean }>();
 
 const { width } = useWindowSize();
 const drawerWidth = computed(() =>
@@ -10,14 +10,9 @@ const drawerWidth = computed(() =>
 </script>
 
 <template>
-  <n-drawer
-    :width="drawerWidth"
-    :auto-focus="false"
-    :block-scroll="false"
-    placement="right"
-  >
+  <n-drawer :width="drawerWidth" :auto-focus="false" placement="right">
     <n-drawer-content
-      :native-scrollbar="false"
+      :native-scrollbar="disableScroll ?? false"
       :scrollbar-props="{ trigger: 'none' }"
     >
       <template #header>

--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -110,6 +110,7 @@ const showCatalogDrawer = ref(false);
     :width="320"
     v-model:show="showCatalogDrawer"
     title="目录"
+    disable-scroll
   >
     <template #action>
       <c-button
@@ -125,7 +126,6 @@ const showCatalogDrawer = ref(false);
       item-resizable
       :default-scroll-key="lastReadChapter?.key"
       :scrollbar-props="{ trigger: 'none' }"
-      style="height: calc(100vh - 68px)"
     >
       <template #default="{ item }">
         <div :key="item.key" style="padding-left: 8px; padding-right: 8px">


### PR DESCRIPTION
修改的点

1. 滑动穿透
移除 drawer上的 block-scroll，解决滑动穿透问题
移除 body 上的 overflow-y，使用默认的 auto 模式。block-scroll 后，html 元素会增加上 overflow: hidden，body 上的 overflow-y：scroll 会导致样式上会有问题

2. 修复 iOS 上不显示 scrollbar 的问题
其他环境使用 n-scrollbar 自带的滚动条，iOS 使用原生的滚动条（[naive-ui 就是这样设计的](https://github.com/tusen-ai/naive-ui/issues/4838)，只是实现起来有 bug）

3. 修复 iOS 上右侧弹出的目录会出现两层滚动条
100vh 的高度和 100% 的高度在 iOS 上的表现是不一样的，100vh 的高度包含了可见区域与底部工具栏的高度，所以会出现 2 层滚动条