### PR TITLE
feat(web): 改进删除评论功能

### DIFF
--- a/web/src/components/comment/CommentItem.vue
+++ b/web/src/components/comment/CommentItem.vue
@@ -1,5 +1,9 @@
 <script lang="ts" setup>
-import { CommentOutlined, MoreVertOutlined } from '@vicons/material';
+import {
+  CommentOutlined,
+  MoreVertOutlined,
+  DeleteOutlined,
+} from '@vicons/material';
 
 import { Locator } from '@/data';
 import { Comment1 } from '@/model/Comment';
@@ -38,16 +42,6 @@ const options = computed(() => {
       });
     }
   }
-  if (
-    whoami.value.asMaintainer ||
-    (whoami.value.username === comment.user.username &&
-      Date.now() / 1000 - comment.createAt < 3600 * 24)
-  ) {
-    options.push({
-      label: '删除',
-      key: 'delete',
-    });
-  }
   return options;
 });
 
@@ -62,6 +56,14 @@ const handleSelect = (key: string) => {
     emit('unhide', comment);
   }
 };
+
+const isDeletable = computed(() => {
+  return (
+    whoami.value.asMaintainer ||
+    (whoami.value.username === comment.user.username &&
+      Date.now() / 1000 - comment.createAt < 3600 * 24)
+  );
+});
 </script>
 
 <template>
@@ -85,6 +87,18 @@ const handleSelect = (key: string) => {
       size="tiny"
       style="margin-right: 4px"
       @action="emit('reply', comment)"
+    />
+
+    <c-button
+      v-if="isDeletable"
+      label="删除"
+      :icon="DeleteOutlined"
+      require-login
+      quaternary
+      type="tertiary"
+      size="tiny"
+      style="margin-right: 4px"
+      @action="emit('delete', comment)"
     />
 
     <n-dropdown trigger="click" :options="options" @select="handleSelect">

--- a/web/src/components/comment/CommentItem.vue
+++ b/web/src/components/comment/CommentItem.vue
@@ -89,8 +89,9 @@ const isDeletable = computed(() => {
       @action="emit('reply', comment)"
     />
 
-    <c-button
+    <c-button-confirm
       v-if="isDeletable"
+      hint="真的要删除评论吗？"
       label="删除"
       :icon="DeleteOutlined"
       require-login

--- a/web/src/components/comment/CommentList.vue
+++ b/web/src/components/comment/CommentList.vue
@@ -100,7 +100,12 @@ const showInput = ref(false);
     v-slot="{ value }"
   >
     <template v-for="comment in value.items">
-      <CommentThread :site="site" :comment="comment" :locked="locked" />
+      <CommentThread
+        :site="site"
+        :comment="comment"
+        :locked="locked"
+        @deleted="loadComments(currentPage)"
+      />
       <n-divider />
     </template>
 

--- a/web/src/components/comment/CommentThread.vue
+++ b/web/src/components/comment/CommentThread.vue
@@ -19,6 +19,10 @@ const pageCount = ref(Math.floor((comment.numReplies + 9) / 10));
 const draftRepo = Locator.draftRepository();
 const draftId = `comment-${site}`;
 
+const emit = defineEmits<{
+  deleted: [];
+}>();
+
 const loadReplies = async (page: number) => {
   const result = await runCatching(
     CommentRepository.listComment({
@@ -53,10 +57,14 @@ const copyComment = (comment: Comment1) =>
     else message.error('复制失败');
   });
 
-const deleteComment = (comment: Comment1) =>
+const deleteComment = (commentToDelete: Comment1) =>
   doAction(
-    CommentRepository.deleteComment(comment.id).then(() => {
-      loadReplies(currentPage.value);
+    CommentRepository.deleteComment(commentToDelete.id).then(() => {
+      if (commentToDelete.id === comment.id) {
+        emit('deleted');
+      } else {
+        loadReplies(currentPage.value);
+      }
     }),
     '删除',
     message,


### PR DESCRIPTION
### Problem

原本在 [web/src/components/comment/CommentThread.vue](../blob/master/web/src/components/comment/CommentThread.vue) 中，删除评论后会调用 `loadReplies` 刷新当前楼中楼。因此，删除一级评论后，在不刷新页面的情况下，看不到评论列表的变化。

### Fix

通过 emit 事件通知父组件 [CommentList](../blob/master/web/src/components/comment/CommentList.vue)，在删除一级评论后调用 `loadComments` 刷新评论列表。

### Feat

此外，将删除评论按钮移出下拉列表。