### PR TITLE
feat(web): 实现章节折叠展开

### DIFF
--- a/web/src/components/ChapterTocItem.vue
+++ b/web/src/components/ChapterTocItem.vue
@@ -93,8 +93,8 @@ const visitedColor = mixColor();
         text
         style="
           font-size: 20px;
-          padding: 10px 0 10px 20px;
-          margin: -10px 0 -10px -20px;
+          padding: 6px 0 6px 12px;
+          margin: -6px 0 -6px -12px;
         "
         @click.stop="emit('toggleExpand')"
       >

--- a/web/src/components/ChapterTocItem.vue
+++ b/web/src/components/ChapterTocItem.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { NText } from 'naive-ui';
+import { NText, NButton, NIcon } from 'naive-ui';
+import { KeyboardArrowUpRound, KeyboardArrowDownRound } from '@vicons/material';
 import CA from '@/components/CA.vue';
 
 import { ReadableTocItem } from '@/pages/novel/components/common';
@@ -9,6 +10,12 @@ const props = defineProps<{
   novelId: string;
   tocItem: ReadableTocItem;
   lastRead?: string;
+  isSeparator: boolean;
+  isExpanded?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'toggleExpand'): void;
 }>();
 
 const type = computed(() => {
@@ -44,38 +51,56 @@ const visitedColor = mixColor();
 
 <template>
   <component
-    :is="tocItem.order !== undefined ? CA : 'div'"
-    :to="`/novel/${providerId}/${novelId}/${tocItem.chapterId}`"
+    :is="!isSeparator ? CA : 'div'"
+    :to="
+      !isSeparator
+        ? `/novel/${providerId}/${novelId}/${tocItem.chapterId}`
+        : undefined
+    "
     class="toc"
     style="width: calc(100% - 12px); display: block; padding: 6px"
-    :style="{ 'font-size': tocItem.order !== undefined ? '14px' : '12px' }"
+    :style="{ 'font-size': !isSeparator ? '14px' : '12px' }"
   >
-    <n-text
-      :class="{
-        'toc-title-visited': type !== undefined && type !== 'warning',
-        'toc-title': type !== undefined,
-      }"
-      :type="type"
+    <div
+      style="display: flex; align-items: center; justify-content: space-between"
     >
-      {{ tocItem.titleJp }}
-    </n-text>
-    <br />
-    <n-text depth="3">
-      {{ tocItem.titleZh }}
-    </n-text>
-    <br />
-    <n-text
-      v-if="tocItem.order !== undefined"
-      depth="3"
-      style="font-size: 12px"
-    >
-      [{{ tocItem.order }}]
-      <n-time
-        v-if="tocItem.createAt"
-        :time="tocItem.createAt * 1000"
-        format="yyyy-MM-dd HH:mm"
-      />
-    </n-text>
+      <div>
+        <n-text
+          :class="{
+            'toc-title-visited': type !== undefined && type !== 'warning',
+            'toc-title': type !== undefined,
+          }"
+          :type="type"
+        >
+          {{ tocItem.titleJp }}
+        </n-text>
+        <br />
+        <n-text depth="3">
+          {{ tocItem.titleZh }}
+        </n-text>
+        <br />
+        <n-text v-if="!isSeparator" depth="3" style="font-size: 12px">
+          [{{ tocItem.order }}]
+          <n-time
+            v-if="tocItem.createAt"
+            :time="tocItem.createAt * 1000"
+            format="yyyy-MM-dd HH:mm"
+          />
+        </n-text>
+      </div>
+      <n-button
+        v-if="isSeparator"
+        text
+        style="font-size: 20px"
+        @click.stop="emit('toggleExpand')"
+      >
+        <n-icon>
+          <component
+            :is="isExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
+          />
+        </n-icon>
+      </n-button>
+    </div>
   </component>
 </template>
 

--- a/web/src/components/ChapterTocItem.vue
+++ b/web/src/components/ChapterTocItem.vue
@@ -91,7 +91,11 @@ const visitedColor = mixColor();
       <n-button
         v-if="isSeparator"
         text
-        style="font-size: 20px"
+        style="
+          font-size: 20px;
+          padding: 10px 0 10px 20px;
+          margin: -10px 0 -10px -20px;
+        "
         @click.stop="emit('toggleExpand')"
       >
         <n-icon>

--- a/web/src/pages/novel/components/UseTocExpansion.ts
+++ b/web/src/pages/novel/components/UseTocExpansion.ts
@@ -105,6 +105,7 @@ export function useTocExpansion(
           chapters: isExpanded ? section.chapters : [],
         };
       }
+      return section;
     });
 
     let result: ReadableTocItem[] = [];

--- a/web/src/pages/novel/components/UseTocExpansion.ts
+++ b/web/src/pages/novel/components/UseTocExpansion.ts
@@ -1,0 +1,141 @@
+import { ref, computed, watch, type Ref, type ComputedRef } from 'vue';
+import type { ReadableTocItem } from '@/pages/novel/components/common';
+
+interface TocSection {
+  separator: ReadableTocItem | null;
+  chapters: ReadableTocItem[];
+}
+
+export function useTocExpansion(
+  toc:
+    | Ref<ReadableTocItem[] | undefined>
+    | ComputedRef<ReadableTocItem[] | undefined>,
+  sortReverse: Ref<boolean> | ComputedRef<boolean>,
+) {
+  const expandedState = ref(new Map<string, boolean>());
+
+  watch(
+    toc,
+    (newToc) => {
+      if (!newToc) return;
+      let hasNewSeparator = false;
+      for (const item of newToc) {
+        if (item.order === undefined) {
+          const key = item.titleJp;
+          if (!expandedState.value.has(key)) {
+            expandedState.value.set(key, true);
+            hasNewSeparator = true;
+          }
+        }
+      }
+      if (hasNewSeparator) {
+        expandedState.value = new Map(expandedState.value);
+      }
+    },
+    { immediate: true, deep: true },
+  );
+
+  const hasSeparators = computed(() => {
+    return toc.value?.some((item) => item.order === undefined) ?? false;
+  });
+
+  const isAnyExpanded = computed(() => {
+    if (!hasSeparators.value || !toc.value) {
+      return false;
+    }
+    for (const item of toc.value) {
+      if (item.order === undefined) {
+        const key = item.titleJp;
+        if (expandedState.value.get(key) ?? true) {
+          return true;
+        }
+      }
+    }
+    return false;
+  });
+
+  const toggleAll = () => {
+    if (!toc.value) return;
+    const targetState = !isAnyExpanded.value;
+    const newState = new Map(expandedState.value);
+    for (const item of toc.value) {
+      if (item.order === undefined) {
+        newState.set(item.titleJp, targetState);
+      }
+    }
+    expandedState.value = newState;
+  };
+
+  const toggleSection = (separatorKey: string) => {
+    const currentState = expandedState.value.get(separatorKey) ?? true;
+    const newState = new Map(expandedState.value);
+    newState.set(separatorKey, !currentState);
+    expandedState.value = newState;
+  };
+
+  const finalToc = computed(() => {
+    if (!toc.value) {
+      return [];
+    }
+    const sections: TocSection[] = [];
+    let currentSection: TocSection = { separator: null, chapters: [] };
+
+    for (const item of toc.value) {
+      if (item.order === undefined) {
+        if (currentSection.separator || currentSection.chapters.length > 0) {
+          sections.push(currentSection);
+        }
+        const key = item.titleJp;
+        if (!expandedState.value.has(key)) {
+          expandedState.value.set(key, true);
+        }
+        currentSection = { separator: item, chapters: [] };
+      } else {
+        currentSection.chapters.push(item);
+      }
+    }
+    sections.push(currentSection);
+
+    const filteredSections = sections.map((section) => {
+      if (section.separator) {
+        const isExpanded =
+          expandedState.value.get(section.separator.titleJp) ?? true;
+        return {
+          ...section,
+          chapters: isExpanded ? section.chapters : [],
+        };
+      }
+    });
+
+    let result: ReadableTocItem[] = [];
+    if (!sortReverse.value) {
+      filteredSections.forEach((section) => {
+        if (!section) return;
+        if (section.separator) {
+          result.push(section.separator);
+        }
+        result.push(...section.chapters);
+      });
+    } else {
+      const reversedSections = filteredSections.slice().reverse();
+      reversedSections.forEach((section) => {
+        if (!section) return;
+        if (section.separator) {
+          result.push(section.separator);
+        }
+        result.push(...section.chapters.slice().reverse());
+      });
+    }
+
+    return result;
+  });
+
+  return {
+    expandedState,
+    hasSeparators,
+    isAnyExpanded,
+    toggleAll,
+    toggleSection,
+    finalToc,
+  };
+}

--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -10,7 +10,7 @@ import { Locator } from '@/data';
 import { WebNovelDto, WebNovelTocItemDto } from '@/model/WebNovel';
 
 import { useToc, useLastReadChapter } from './UseWebNovel';
-import { useTocExpansion } from './useTocExpansion';
+import { useTocExpansion } from './UseTocExpansion';
 
 const props = defineProps<{
   providerId: string;
@@ -150,9 +150,7 @@ const {
               : undefined
           "
           @toggle-expand="
-            item.order === undefined
-              ? () => toggleSection(item.titleJp)
-              : () => {}
+            item.order === undefined ? toggleSection(item.titleJp) : () => {}
           "
         />
       </n-list-item>
@@ -183,7 +181,6 @@ const {
     <n-virtual-list
       :item-size="78"
       :items="finalToc"
-      item-resizable
       :default-scroll-key="lastReadChapter?.key"
       :scrollbar-props="{ trigger: 'none' }"
     >

--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -96,7 +96,7 @@ const {
     >
       <c-button
         v-if="hasSeparators"
-        :label="isAnyExpanded ? '折叠所有' : '展开所有'"
+        :label="isAnyExpanded ? '全部折叠' : '全部展开'"
         :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
         @action="toggleAll"
         quaternary

--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -1,10 +1,16 @@
 <script lang="ts" setup>
-import { SortOutlined } from '@vicons/material';
+import {
+  SortOutlined,
+  KeyboardArrowUpRound,
+  KeyboardArrowDownRound,
+} from '@vicons/material';
+import { ref, computed } from 'vue';
 
 import { Locator } from '@/data';
 import { WebNovelDto, WebNovelTocItemDto } from '@/model/WebNovel';
 
 import { useToc, useLastReadChapter } from './UseWebNovel';
+import { useTocExpansion } from './useTocExpansion';
 
 const props = defineProps<{
   providerId: string;
@@ -13,6 +19,7 @@ const props = defineProps<{
 }>();
 
 const { setting } = Locator.settingRepository();
+const sortReverse = computed(() => setting.value.tocSortReverse);
 
 const { toc } = useToc(props.novel);
 const { lastReadChapter } = useLastReadChapter(props.novel, toc);
@@ -24,6 +31,15 @@ const startReadChapter = computed(() => {
 });
 
 const showCatalogDrawer = ref(false);
+
+const {
+  expandedState,
+  hasSeparators,
+  isAnyExpanded,
+  toggleAll,
+  toggleSection,
+  finalToc,
+} = useTocExpansion(toc, sortReverse);
 </script>
 
 <template>
@@ -58,6 +74,8 @@ const showCatalogDrawer = ref(false);
       :novel-id="novelId"
       :toc-item="startReadChapter"
       :last-read="novel.lastReadChapterId"
+      :is-separator="false"
+      :is-expanded="false"
     />
     <c-button
       v-if="novel.toc.length > 1"
@@ -68,12 +86,31 @@ const showCatalogDrawer = ref(false);
     />
   </template>
   <template v-else>
-    <c-button
-      :label="setting.tocSortReverse ? '倒序' : '正序'"
-      :icon="SortOutlined"
-      @action="setting.tocSortReverse = !setting.tocSortReverse"
-      style="margin-bottom: 16px"
-    />
+    <div
+      style="
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 16px;
+      "
+    >
+      <c-button
+        v-if="hasSeparators"
+        :label="isAnyExpanded ? '折叠所有' : '展开所有'"
+        :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
+        @action="toggleAll"
+        quaternary
+        size="small"
+      />
+      <div v-else style="flex: 1"></div>
+      <c-button
+        :label="setting.tocSortReverse ? '倒序' : '正序'"
+        :icon="SortOutlined"
+        @action="setting.tocSortReverse = !setting.tocSortReverse"
+        quaternary
+        size="small"
+      />
+    </div>
     <n-list>
       <n-card
         v-if="lastReadChapter !== undefined"
@@ -88,18 +125,35 @@ const showCatalogDrawer = ref(false);
           :novel-id="novelId"
           :toc-item="lastReadChapter"
           :last-read="novel.lastReadChapterId"
+          :is-separator="false"
+          :is-expanded="false"
         />
       </n-card>
       <n-list-item
-        v-for="tocItem in setting.tocSortReverse ? toc.slice().reverse() : toc"
-        :key="tocItem.key"
+        v-for="item in finalToc"
+        :key="
+          item.order === undefined
+            ? `sep-${item.titleJp}`
+            : `ch-${item.chapterId}`
+        "
         style="padding: 0px"
       >
         <chapter-toc-item
           :provider-id="providerId"
           :novel-id="novelId"
-          :toc-item="tocItem"
+          :toc-item="item"
           :last-read="novel.lastReadChapterId"
+          :is-separator="item.order === undefined"
+          :is-expanded="
+            item.order === undefined
+              ? expandedState.get(item.titleJp)
+              : undefined
+          "
+          @toggle-expand="
+            item.order === undefined
+              ? () => toggleSection(item.titleJp)
+              : () => {}
+          "
         />
       </n-list-item>
     </n-list>
@@ -114,6 +168,12 @@ const showCatalogDrawer = ref(false);
   >
     <template #action>
       <c-button
+        v-if="hasSeparators"
+        :label="isAnyExpanded ? '折叠' : '展开'"
+        :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
+        @action="toggleAll"
+      />
+      <c-button
         :label="setting.tocSortReverse ? '倒序' : '正序'"
         :icon="SortOutlined"
         @action="setting.tocSortReverse = !setting.tocSortReverse"
@@ -122,18 +182,34 @@ const showCatalogDrawer = ref(false);
 
     <n-virtual-list
       :item-size="78"
-      :items="setting.tocSortReverse ? toc.slice().reverse() : toc"
+      :items="finalToc"
       item-resizable
       :default-scroll-key="lastReadChapter?.key"
       :scrollbar-props="{ trigger: 'none' }"
     >
       <template #default="{ item }">
-        <div :key="item.key" style="padding-left: 8px; padding-right: 8px">
+        <div
+          :key="
+            item.order === undefined
+              ? `sep-${item.titleJp}`
+              : `ch-${item.chapterId}`
+          "
+          style="padding-left: 8px; padding-right: 8px"
+        >
           <chapter-toc-item
             :provider-id="providerId"
             :novel-id="novelId"
             :toc-item="item"
             :last-read="novel.lastReadChapterId"
+            :is-separator="item.order === undefined"
+            :is-expanded="
+              item.order === undefined
+                ? expandedState.get(item.titleJp)
+                : undefined
+            "
+            @toggle-expand="
+              item.order === undefined ? toggleSection(item.titleJp) : () => {}
+            "
           />
         </div>
       </template>

--- a/web/src/pages/novel/components/WebNovelWide.vue
+++ b/web/src/pages/novel/components/WebNovelWide.vue
@@ -10,7 +10,7 @@ import { Locator } from '@/data';
 import { WebNovelTocItemDto, WebNovelDto } from '@/model/WebNovel';
 
 import { useToc, useLastReadChapter } from './UseWebNovel';
-import { useTocExpansion } from './useTocExpansion';
+import { useTocExpansion } from './UseTocExpansion';
 
 const props = defineProps<{
   providerId: string;
@@ -82,7 +82,6 @@ const {
       <n-virtual-list
         :item-size="78"
         :items="finalToc"
-        item-resizable
         :default-scroll-key="lastReadChapter?.key"
         :scrollbar-props="{ trigger: 'none' }"
         style="flex: 1"

--- a/web/src/pages/novel/components/WebNovelWide.vue
+++ b/web/src/pages/novel/components/WebNovelWide.vue
@@ -68,7 +68,7 @@ const {
       <section-header title="目录">
         <c-button
           v-if="hasSeparators"
-          :label="isAnyExpanded ? '折叠' : '展开'"
+          :label="isAnyExpanded ? '全部折叠' : '全部展开'"
           :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
           @action="toggleAll"
         />

--- a/web/src/pages/reader/components/CatalogModal.vue
+++ b/web/src/pages/reader/components/CatalogModal.vue
@@ -9,7 +9,7 @@ import { GenericNovelId } from '@/model/Common';
 import { useWebNovelStore } from '@/pages/novel/WebNovelStore';
 import { Ok, Result, runCatching } from '@/util/result';
 import { ReadableTocItem } from '@/pages/novel/components/common';
-import { useTocExpansion } from '@/pages/novel/components/useTocExpansion';
+import { useTocExpansion } from '@/pages/novel/components/UseTocExpansion';
 
 const props = defineProps<{
   show: boolean;
@@ -150,7 +150,6 @@ const onTocItemClick = (chapterId: string | undefined) => {
       <n-virtual-list
         v-if="gnid.type == 'web'"
         :item-size="78"
-        item-resizable
         :items="finalToc"
         :default-scroll-key="currentKey"
         :scrollbar-props="{ trigger: 'none' }"
@@ -188,7 +187,6 @@ const onTocItemClick = (chapterId: string | undefined) => {
       <n-virtual-list
         v-else-if="gnid.type == 'local'"
         :item-size="78"
-        item-resizable
         :items="finalToc"
         :default-scroll-key="currentKey"
         :scrollbar-props="{ trigger: 'none' }"

--- a/web/src/pages/reader/components/CatalogModal.vue
+++ b/web/src/pages/reader/components/CatalogModal.vue
@@ -127,7 +127,7 @@ const onTocItemClick = (chapterId: string | undefined) => {
         <div style="flex: 1" />
         <c-button
           v-if="hasSeparators"
-          :label="isAnyExpanded ? '折叠' : '展开'"
+          :label="isAnyExpanded ? '全部折叠' : '全部展开'"
           :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
           quaternary
           size="small"

--- a/web/src/pages/reader/components/CatalogModal.vue
+++ b/web/src/pages/reader/components/CatalogModal.vue
@@ -1,9 +1,15 @@
 <script lang="ts" setup>
-import { SortOutlined } from '@vicons/material';
+import {
+  SortOutlined,
+  KeyboardArrowUpRound,
+  KeyboardArrowDownRound,
+} from '@vicons/material';
 import { Locator } from '@/data';
 import { GenericNovelId } from '@/model/Common';
 import { useWebNovelStore } from '@/pages/novel/WebNovelStore';
 import { Ok, Result, runCatching } from '@/util/result';
+import { ReadableTocItem } from '@/pages/novel/components/common';
+import { useTocExpansion } from '@/pages/novel/components/useTocExpansion';
 
 const props = defineProps<{
   show: boolean;
@@ -15,21 +21,31 @@ const emit = defineEmits<{
   'update:show': [boolean];
 }>();
 
-type TocItem = {
+type TocItem = ReadableTocItem & {
   key: number;
-  titleJp: string;
-  titleZh?: string;
-  chapterId?: string;
-  createAt?: number;
 };
+
 const tocResult = shallowRef<Result<TocItem[]>>();
 
+const tocData = computed(() =>
+  tocResult.value?.ok ? tocResult.value.value : undefined,
+);
+
 const tocNumber = computed(() => {
-  if (tocResult.value?.ok === true) {
-    return tocResult.value.value.filter((it) => it.chapterId !== undefined)
-      .length;
-  }
+  return tocData.value?.filter((it) => it.chapterId !== undefined).length;
 });
+
+const { setting } = Locator.settingRepository();
+const sortReverse = computed(() => setting.value.tocSortReverse);
+
+const {
+  expandedState,
+  hasSeparators,
+  isAnyExpanded,
+  toggleAll,
+  toggleSection,
+  finalToc,
+} = useTocExpansion(tocData, sortReverse);
 
 watch(
   () => props.show,
@@ -40,17 +56,16 @@ watch(
         const result = await store.loadNovel();
         if (result.ok) {
           let order = 0;
-          return Ok(
-            result.value.toc.map((it, index) => {
-              const tocItem = <TocItem>{
-                ...it,
-                key: index,
-                order: it.chapterId ? order : undefined,
-              };
-              if (it.chapterId) order += 1;
-              return tocItem;
-            }),
-          );
+          const tocItems = result.value.toc.map((it, index) => {
+            const tocItem = <TocItem>{
+              ...it,
+              key: index,
+              order: it.chapterId ? order : undefined,
+            };
+            if (it.chapterId) order += 1;
+            return tocItem;
+          });
+          return Ok(tocItems);
         } else {
           return result;
         }
@@ -83,12 +98,7 @@ watch(
 );
 
 const currentKey = computed(() => {
-  if (tocResult.value?.ok !== true) {
-    return undefined;
-  } else {
-    return tocResult.value.value.find((it) => it.chapterId === props.chapterId)
-      ?.key;
-  }
+  return tocData.value?.find((it) => it.chapterId === props.chapterId)?.key;
 });
 
 const onTocItemClick = (chapterId: string | undefined) => {
@@ -96,8 +106,6 @@ const onTocItemClick = (chapterId: string | undefined) => {
     emit('update:show', false);
   }
 };
-
-const { setting } = Locator.settingRepository();
 </script>
 
 <template>
@@ -118,6 +126,16 @@ const { setting } = Locator.settingRepository();
         </n-text>
         <div style="flex: 1" />
         <c-button
+          v-if="hasSeparators"
+          :label="isAnyExpanded ? '折叠' : '展开'"
+          :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
+          quaternary
+          size="small"
+          :round="false"
+          @action="toggleAll"
+          style="margin-right: 8px"
+        />
+        <c-button
           :label="setting.tocSortReverse ? '倒序' : '正序'"
           :icon="SortOutlined"
           quaternary
@@ -128,12 +146,12 @@ const { setting } = Locator.settingRepository();
       </div>
     </template>
 
-    <c-result :result="tocResult" v-slot="{ value: toc }">
+    <c-result :result="tocResult" v-slot="{ value: _ }">
       <n-virtual-list
         v-if="gnid.type == 'web'"
-        :item-size="20"
+        :item-size="78"
         item-resizable
-        :items="setting.tocSortReverse ? toc.slice().reverse() : toc"
+        :items="finalToc"
         :default-scroll-key="currentKey"
         :scrollbar-props="{ trigger: 'none' }"
         style="max-height: 60vh"
@@ -141,7 +159,9 @@ const { setting } = Locator.settingRepository();
         <template #default="{ item }">
           <div
             :key="
-              item.chapterId === undefined ? `/${item.titleJp}` : item.chapterId
+              item.order === undefined
+                ? `sep-${item.titleJp}`
+                : `ch-${item.chapterId}`
             "
           >
             <chapter-toc-item
@@ -149,6 +169,40 @@ const { setting } = Locator.settingRepository();
               :novel-id="gnid.novelId"
               :toc-item="item"
               :last-read="chapterId"
+              :is-separator="item.order === undefined"
+              :is-expanded="
+                item.order === undefined
+                  ? expandedState.get(item.titleJp)
+                  : undefined
+              "
+              @click="() => onTocItemClick(item.chapterId)"
+              @toggle-expand="
+                item.order === undefined
+                  ? toggleSection(item.titleJp)
+                  : () => {}
+              "
+            />
+          </div>
+        </template>
+      </n-virtual-list>
+      <n-virtual-list
+        v-else-if="gnid.type == 'local'"
+        :item-size="78"
+        item-resizable
+        :items="finalToc"
+        :default-scroll-key="currentKey"
+        :scrollbar-props="{ trigger: 'none' }"
+        style="max-height: 60vh"
+      >
+        <template #default="{ item }">
+          <div :key="item.key">
+            <chapter-toc-item
+              :provider-id="gnid.volumeId"
+              :novel-id="gnid.volumeId"
+              :toc-item="item"
+              :last-read="chapterId"
+              :is-separator="false"
+              :is-expanded="false"
               @click="() => onTocItemClick(item.chapterId)"
             />
           </div>


### PR DESCRIPTION
为 web 小说的章节目录添加了折叠展开，适配正序/倒序。

除了每一节右侧添加折叠/展开按钮，目录上方也添加全部折叠/全部展开的按钮（目前的行为：有任何一节则显示全部折叠，否则显示全部展开）。

折叠/展开的设置并不会像正序/倒序一样保存，每次加载目录时默认全部展开，这是有意的（因为总归是要看章节的）。