### PR TITLE
chore(web): 改进全部展开/折叠样式

### DIFF
--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -21,6 +21,10 @@ const props = defineProps<{
 const { setting } = Locator.settingRepository();
 const sortReverse = computed(() => setting.value.tocSortReverse);
 
+const defaultTocExpanded = computed(
+  () => setting.value.tocCollapseInNarrowScreen,
+);
+
 const { toc } = useToc(props.novel);
 const { lastReadChapter } = useLastReadChapter(props.novel, toc);
 const startReadChapter = computed(() => {
@@ -39,7 +43,7 @@ const {
   toggleAll,
   toggleSection,
   finalToc,
-} = useTocExpansion(toc, sortReverse);
+} = useTocExpansion(toc, sortReverse, defaultTocExpanded);
 </script>
 
 <template>
@@ -149,7 +153,7 @@ const {
           :is-separator="item.order === undefined"
           :is-expanded="
             item.order === undefined
-              ? expandedState.get(item.titleJp)
+              ? expandedState.get(item.titleJp) ?? defaultTocExpanded
               : undefined
           "
           @toggle-expand="
@@ -170,7 +174,7 @@ const {
     <template #action>
       <c-button
         v-if="hasSeparators"
-        :label="isAnyExpanded ? '全部折叠' : '全部展开'"
+        :label="isAnyExpanded ? '折叠' : '展开'"
         :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
         quaternary
         size="small"
@@ -211,7 +215,7 @@ const {
             :is-separator="item.order === undefined"
             :is-expanded="
               item.order === undefined
-                ? expandedState.get(item.titleJp)
+                ? expandedState.get(item.titleJp) ?? defaultTocExpanded
                 : undefined
             "
             @toggle-expand="

--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -94,21 +94,24 @@ const {
         margin-bottom: 16px;
       "
     >
+      <div style="flex: 1"></div>
       <c-button
         v-if="hasSeparators"
         :label="isAnyExpanded ? '全部折叠' : '全部展开'"
         :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
-        @action="toggleAll"
         quaternary
         size="small"
+        :round="false"
+        @action="toggleAll"
+        style="margin-right: 8px"
       />
-      <div v-else style="flex: 1"></div>
       <c-button
         :label="setting.tocSortReverse ? '倒序' : '正序'"
         :icon="SortOutlined"
-        @action="setting.tocSortReverse = !setting.tocSortReverse"
         quaternary
         size="small"
+        :round="false"
+        @action="setting.tocSortReverse = !setting.tocSortReverse"
       />
     </div>
     <n-list>
@@ -167,13 +170,20 @@ const {
     <template #action>
       <c-button
         v-if="hasSeparators"
-        :label="isAnyExpanded ? '折叠' : '展开'"
+        :label="isAnyExpanded ? '全部折叠' : '全部展开'"
         :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
+        quaternary
+        size="small"
+        :round="false"
         @action="toggleAll"
+        style="margin-right: 8px"
       />
       <c-button
         :label="setting.tocSortReverse ? '倒序' : '正序'"
         :icon="SortOutlined"
+        quaternary
+        size="small"
+        :round="false"
         @action="setting.tocSortReverse = !setting.tocSortReverse"
       />
     </template>

--- a/web/src/pages/novel/components/WebNovelWide.vue
+++ b/web/src/pages/novel/components/WebNovelWide.vue
@@ -70,11 +70,18 @@ const {
           v-if="hasSeparators"
           :label="isAnyExpanded ? '全部折叠' : '全部展开'"
           :icon="isAnyExpanded ? KeyboardArrowUpRound : KeyboardArrowDownRound"
+          quaternary
+          size="small"
+          :round="false"
           @action="toggleAll"
+          style="margin-right: 8px"
         />
         <c-button
           :label="setting.tocSortReverse ? '倒序' : '正序'"
           :icon="SortOutlined"
+          quaternary
+          size="small"
+          :round="false"
           @action="setting.tocSortReverse = !setting.tocSortReverse"
         />
       </section-header>

--- a/web/src/pages/novel/components/WebNovelWide.vue
+++ b/web/src/pages/novel/components/WebNovelWide.vue
@@ -24,6 +24,8 @@ const sortReverse = computed(() => setting.value.tocSortReverse);
 const { toc } = useToc(props.novel);
 const { lastReadChapter } = useLastReadChapter(props.novel, toc);
 
+const defaultTocExpanded = ref(true);
+
 const {
   expandedState,
   hasSeparators,
@@ -31,7 +33,7 @@ const {
   toggleAll,
   toggleSection,
   finalToc,
-} = useTocExpansion(toc, sortReverse);
+} = useTocExpansion(toc, sortReverse, defaultTocExpanded);
 </script>
 
 <template>

--- a/web/src/pages/reader/components/CatalogModal.vue
+++ b/web/src/pages/reader/components/CatalogModal.vue
@@ -38,6 +38,8 @@ const tocNumber = computed(() => {
 const { setting } = Locator.settingRepository();
 const sortReverse = computed(() => setting.value.tocSortReverse);
 
+const defaultTocExpanded = ref(true);
+
 const {
   expandedState,
   hasSeparators,
@@ -45,7 +47,7 @@ const {
   toggleAll,
   toggleSection,
   finalToc,
-} = useTocExpansion(tocData, sortReverse);
+} = useTocExpansion(tocData, sortReverse, defaultTocExpanded);
 
 watch(
   () => props.show,


### PR DESCRIPTION
接续 #168 ，提供一个修改的样式。

电脑端、移动端抽屉模式：

![屏幕截图 2025-04-23 010443](https://github.com/user-attachments/assets/6e537a06-b65d-460e-9943-141021089a74)

移动端非抽屉模式（默认全部折叠）：

![image](https://github.com/user-attachments/assets/b94fe8e3-55b2-4d6d-814d-6196b9cde3ca)

