### PR TITLE
fix(server): 修改文库和 web 的 EPUB&TXT 生成

### DIFF
--- a/server/src/main/kotlin/infra/web/repository/makeEpub.kt
+++ b/server/src/main/kotlin/infra/web/repository/makeEpub.kt
@@ -2,6 +2,7 @@ package infra.web.repository
 
 import infra.web.WebNovel
 import infra.web.WebNovelTocItem
+import util.MachineTranslationSignature
 import util.epub.EpubBook
 import util.epub.Navigation
 import util.epub.createEpubXhtml
@@ -36,6 +37,8 @@ suspend fun makeEpubFile(
     epub.addTitle(title)
     epub.addLanguage(language)
     epub.addDescription(introduction)
+    // 添加机翻标识, Issue #134
+    epub.addDescription(MachineTranslationSignature())
     epub.addNavigation(
         identifier,
         Navigation(

--- a/server/src/main/kotlin/infra/web/repository/makeEpub.kt
+++ b/server/src/main/kotlin/infra/web/repository/makeEpub.kt
@@ -2,7 +2,7 @@ package infra.web.repository
 
 import infra.web.WebNovel
 import infra.web.WebNovelTocItem
-import util.MachineTranslationSignature
+import util.Signature as Sig
 import util.epub.EpubBook
 import util.epub.Navigation
 import util.epub.createEpubXhtml
@@ -38,7 +38,7 @@ suspend fun makeEpubFile(
     epub.addLanguage(language)
     epub.addDescription(introduction)
     // 添加机翻标识, Issue #134
-    epub.addDescription(MachineTranslationSignature())
+    epub.addDescription(Sig.text())
     epub.addNavigation(
         identifier,
         Navigation(

--- a/server/src/main/kotlin/infra/web/repository/makeTxt.kt
+++ b/server/src/main/kotlin/infra/web/repository/makeTxt.kt
@@ -5,6 +5,7 @@ import infra.web.WebNovel
 import infra.web.WebNovelTocItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import util.MachineTranslationSignature
 import java.io.BufferedWriter
 import java.nio.file.Path
 import kotlin.io.path.bufferedWriter
@@ -73,6 +74,10 @@ private class TxtWriter(
         write("${translation}翻译缺失。\n\n")
     }
 
+    private fun BufferedWriter.writeMachineTranslationSig() {
+        if (zh) write("※ ${MachineTranslationSignature()}\n")
+    }
+
     fun BufferedWriter.writeNovel(
         novel: WebNovel,
         chapters: Map<String, ChapterWriteData>,
@@ -80,6 +85,8 @@ private class TxtWriter(
         writeTitle(novel)
         write("\n")
         writeAuthor(novel)
+        write("\n")
+        writeMachineTranslationSig()
         write("\n")
         write("#".repeat(12) + "\n")
         writeIntroduction(novel)

--- a/server/src/main/kotlin/infra/web/repository/makeTxt.kt
+++ b/server/src/main/kotlin/infra/web/repository/makeTxt.kt
@@ -5,7 +5,7 @@ import infra.web.WebNovel
 import infra.web.WebNovelTocItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import util.MachineTranslationSignature
+import util.Signature as Sig;
 import java.io.BufferedWriter
 import java.nio.file.Path
 import kotlin.io.path.bufferedWriter
@@ -75,7 +75,7 @@ private class TxtWriter(
     }
 
     private fun BufferedWriter.writeMachineTranslationSig() {
-        if (zh) write("※ ${MachineTranslationSignature()}\n")
+        if (zh) write("※ ${Sig.text()}\n")
     }
 
     fun BufferedWriter.writeNovel(

--- a/server/src/main/kotlin/util/Signature.kt
+++ b/server/src/main/kotlin/util/Signature.kt
@@ -1,0 +1,5 @@
+package util
+
+fun MachineTranslationSignature(): String {
+    return "本内容为机器翻译"
+}

--- a/server/src/main/kotlin/util/Signature.kt
+++ b/server/src/main/kotlin/util/Signature.kt
@@ -1,5 +1,46 @@
 package util
 
-fun MachineTranslationSignature(): String {
-    return "本内容为机器翻译"
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+
+object Signature {
+    fun text(): String {
+        return "本文档内容为机器翻译生成"
+    }
+
+    private var TEMPLATE_NAV = """
+        <div style="background-color: #fff8c5; border: 1px solid #ffd33d; border-radius: 6px; padding: 16px; margin: 16px 0; display: flex; align-items: flex-start; gap: 12px;">
+          <p style="">ℹ️ <strong>注意:</strong></p>
+          <p style="color: #3d2a00;">
+            ${text()}
+          </p>
+        </div>
+    """
+
+    val epubNav: Element by lazy {
+        Jsoup.parseBodyFragment(TEMPLATE_NAV.trimIndent())
+            .body()
+            .child(0)
+    }
+
+
+    fun epubNcx(content: String? = null): Element {
+        val template_ncx = """
+            <navPoint>
+                <navLabel>
+                    <text> ${text()} </text>
+                </navLabel>
+                ${ 
+                    if (content != null)  
+                        "<content src=\"$content\"/>" 
+                    else  
+                        "" 
+                }
+                
+            </navPoint>
+        """
+        return Jsoup.parseBodyFragment(template_ncx.trimIndent())
+            .body()
+            .child(0)
+    }
 }

--- a/server/src/main/kotlin/util/epub/Epub.kt
+++ b/server/src/main/kotlin/util/epub/Epub.kt
@@ -5,7 +5,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.parser.Parser
-import util.MachineTranslationSignature
+import util.Signature as Sig
 import java.io.BufferedOutputStream
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
@@ -35,6 +35,23 @@ object Epub {
                 .select("manifest item[media-type=application/xhtml+xml]")
                 .map { opfDir + "/" + it.attr("href") }
                 .forEach { block(it, fs.readFileAsXHtml(it)) }
+        }
+    }
+
+    fun readContentOpf(srcPath: Path): Document? {
+        return FileSystems.newFileSystem(srcPath).use { fs ->
+            Files
+                .walk(fs.rootDirectories.first())
+                .filter { it.isRegularFile() }
+                .asSequence()
+                .forEach { path ->
+                    val name = path.toString().removePrefix("/")
+                    if (name.contains("content.opf")) {
+                        val doc = Jsoup.parse(path.readBytes().decodeToString())
+                        return@use doc
+                    }
+                }
+            null
         }
     }
 
@@ -87,7 +104,7 @@ object Epub {
         // 添加机翻标识, Issue #134
         doc.head().appendElement("meta")
             .attr("name", "translation")
-            .attr("content", MachineTranslationSignature())
+            .attr("content", Sig.text())
 
         // Fix: <html xmlns="..." xmlns:epub="..." xml:lang="ja" class="vrtl">
         doc.head()
@@ -123,35 +140,33 @@ object Epub {
                 }
             }
         doc.outputSettings().prettyPrint(true)
-        return doc;
+        return doc
     }
 
+    // 防止每次调用 fixInvalidEpub 的时候都重新编译 regex 和创建 String Obj
+    private val xmlDeclarationRegex = Regex("""<\?xml\s+.+?\?>""")
+    private const val XML_DECLARATION = """<?xml version="1.0" encoding="utf-8"?>"""
+
+    private val doctypeDeclarationRegex = Regex("""(?i)<!DOCTYPE\s+.*?>""")
+    private const val DOCTYPE_DECLARATION = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">"""
     fun fixInvalidEpub(docString: String): String {
-        var xmlString = docString;
+        var xmlString = docString
 
         // NOTE(kuriko): fix iOS epub reader not working, Issue #85.
         // fix: replacing `<?xml version='1.0' encoding='utf-8'?>`
-        val xmlDeclaration = """<?xml version="1.0" encoding="utf-8"?>"""
-        val xmlDeclarationRegex = Regex("""<\?xml\s+.+?\?>""")
         xmlString = if (xmlDeclarationRegex.containsMatchIn(xmlString)) {
-            // 找到，替换为标准 xml 规范
-            xmlString.replace(xmlDeclarationRegex, xmlDeclaration)
+            xmlString.replace(xmlDeclarationRegex, XML_DECLARATION)
         } else {
-            // 未找到，创建一个新的
-            "${xmlDeclaration}\n${xmlString}"
+            "${XML_DECLARATION}\n${xmlString}"
         }
 
         // fix: missing <!DOCTYPE html>
         // 实际上这个是 EPUB v3 规范，为了最大兼容性， 我们采用 EPUB v2 规范的 doctype
         // 毕竟说不好 content.opf 里面会不会写的是 <package version=2.0>
-        val doctypeDeclaration = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">"""
-        val doctypeDeclarationRegex = Regex("""(?i)<!DOCTYPE\s+.*?>""")
         xmlString = if (doctypeDeclarationRegex.containsMatchIn(xmlString)) {
-            // 找到，替换为标准 EPUB v2 规范
-            xmlString.replace(doctypeDeclarationRegex, doctypeDeclaration)
+            xmlString.replace(doctypeDeclarationRegex, DOCTYPE_DECLARATION)
         } else {
-            // 未找到，创建一个新的
-            xmlString.replace(xmlDeclarationRegex, "${xmlDeclaration}\n${doctypeDeclaration}")
+            xmlString.replace(xmlDeclarationRegex, "${XML_DECLARATION}\n${DOCTYPE_DECLARATION}")
         }
 
         val doc = Jsoup.parse(xmlString, Parser.xmlParser())
@@ -171,5 +186,71 @@ object Epub {
 
         doc.outputSettings().prettyPrint(true)
         return doc.html()
+    }
+
+    fun fixInvalidOpf(bytesIn: ByteArray): ByteArray {
+        val doc = Jsoup.parse(bytesIn.decodeToString(), Parser.xmlParser())
+
+        // 防止部分阅读器使用竖排
+        doc
+            .selectFirst("spine")
+            ?.removeAttr("page-progression-direction")
+
+        // 修改 EPUB 语言为简体中文（让 iOS iBook 阅读器可以使用中文字体）
+        // Fix Issue #58
+        doc
+            .selectFirst("metadata")
+            ?.apply {
+                selectFirst("dc|language")
+                    ?.text("zh-CN")
+                    ?: appendChild(Element("dc:language").text("zh-CN"))
+            }
+
+        // 添加机翻标识, Issue #134
+        doc
+            .selectFirst("metadata")
+            ?.appendChild(Element("dc:description").text(Sig.text()))
+
+        // fix: 竖排转横排文本后，翻页方向问题。 Issue #107
+        //     <meta name="primary-writing-mode" content="vertical-rl"/>
+        //     <meta name="primary-writing-mode" content="horizontal-lr"/>
+        doc
+            .selectFirst("metadata")
+            ?.apply {
+                val metaNode = Element("meta")
+                    .attr("name", "primary-writing-mode")
+                    .attr("content", "horizontal-lr")
+                selectFirst("meta[name=primary-writing-mode]")
+                    ?.replaceWith(metaNode)
+                    ?: appendChild(metaNode)
+            }
+
+        doc.outputSettings().prettyPrint(true)
+        return doc.html().toByteArray()
+    }
+
+    fun addSigToNcx(bytesIn: ByteArray, link: String?): ByteArray {
+        val doc = Jsoup.parse(bytesIn.decodeToString())
+
+        doc.selectFirst("navMap")
+            ?.insertChildren(0, Sig.epubNcx(link))
+
+        doc.outputSettings().prettyPrint(true)
+        return doc.html().toByteArray()
+    }
+
+    fun addSigToNav(bytesIn: ByteArray): ByteArray {
+        val doc = Jsoup.parse(bytesIn.decodeToString())
+
+        // FIXME(kuriko): 目前还没看到有用 epub v3 标准的生肉，
+        //  因此这个大概、也许不会被触发。
+        //  另外尴尬的是，如果真的用 v3，生肉的排版很可能也没有用 ol-li 形式
+        //  说不定大概率用的是 p 暴力列举。
+        //  因此直接尝试暴力将 sig 加载 body 开头。
+        doc.selectFirst("body")
+            ?.insertChildren(0, Sig.epubNav)
+
+        doc.outputSettings().prettyPrint(true)
+        return doc.html().toByteArray()
     }
 }

--- a/server/src/main/kotlin/util/epub/EpubResource.kt
+++ b/server/src/main/kotlin/util/epub/EpubResource.kt
@@ -20,6 +20,7 @@ private const val TEMPLATE_XHTML = """<?xml version="1.0" encoding="utf-8"?>
   <head>
     <title/>
     <meta charset="utf-8"/>
+    <meta name="translation" content="本内容为机器翻译" />
   </head>
   <body />
 </html>"""

--- a/server/src/main/kotlin/util/epub/EpubResource.kt
+++ b/server/src/main/kotlin/util/epub/EpubResource.kt
@@ -5,6 +5,7 @@ import org.jsoup.nodes.Attributes
 import org.jsoup.nodes.Element
 import org.jsoup.parser.Parser
 import org.jsoup.parser.Tag
+import util.Signature as Sig
 
 data class EpubResource(
     val path: String,
@@ -87,6 +88,10 @@ fun createEpubNav(
     val nav = body.appendElement("nav")
         .attr("epub:type", "toc")
     nav.appendElement("h2").appendText(navigation.title)
+
+    // 添加机翻标识, Issue #134
+    nav.appendChild(Sig.epubNav)
+
     val ol = nav.appendElement("ol")
     navigation.items.forEach {
         val li = ol.appendElement("li")
@@ -127,6 +132,10 @@ fun createEpubNcx(
         .appendText(navigation.title)
 
     val navMap = ncx.appendElement("navMap")
+
+    // 添加机翻标识, Issue #134
+    navMap.appendChild(Sig.epubNcx("nav.xhtml"))
+
     navigation.items.forEachIndexed { index, it ->
         if (it.href != null) {
             val navPoint = navMap.appendElement("navPoint")


### PR DESCRIPTION
- 修正文库 epub 导出，尽量修复破损的 epub 文件 (Close #85)
- 为文库 epub&txt 添加机翻标识 (Close #134)
- 修正竖排转横排后的 primary-writing-mode (Close #107)