### PR TITLE
feat(server): 将原作添加为hameln的Tag

### DIFF
--- a/server/src/main/kotlin/infra/web/datasource/providers/Hameln.kt
+++ b/server/src/main/kotlin/infra/web/datasource/providers/Hameln.kt
@@ -86,6 +86,9 @@ class Hameln(
 
         val attentions = mutableSetOf<WebNovelAttention>()
         val keywords = mutableListOf<String>()
+        row("原作").select("a").map { it.text() }.forEach {
+            keywords.add(it)
+        }
         listOf("タグ", "必須タグ")
             .flatMap { row(it).select("a") }
             .map { it.text() }


### PR DESCRIPTION
[论坛](https://books.fishhawk.top/forum/66652cc19a36476f0e19546e)帖子

不过非二创也带原作标签 , 个人感觉这种添加到tag里面也可以吧, 不过绿站其他几个站点好像没把这种算作tag

添加后
[https://syosetu.org/novel/137505](https://syosetu.org/novel/137505)   (二创)
![image](https://github.com/user-attachments/assets/d8557917-4cee-40de-b8ff-b599714c9f6f)
[https://syosetu.org/novel/232822](https://syosetu.org/novel/232822) (原创)
![image](https://github.com/user-attachments/assets/68f914df-1c7a-4b80-a63d-e8acb6f67108)

