### PR TITLE
fix(web): 允许markdown表格标题换行

### DIFF
--- a/web/src/components/markdown/MarkdownView.vue
+++ b/web/src/components/markdown/MarkdownView.vue
@@ -177,7 +177,6 @@ md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
   border-collapse: collapse;
 }
 .markdown th {
-  white-space: nowrap;
   background-color: var(--action-color);
 }
 .markdown th,


### PR DESCRIPTION
允许论坛表格换行, 防止长表格在宽度不够的情况下显示不全

比如[这个论坛帖子](https://books.fishhawk.top/forum/680d11e409bd607077249877), 在我的手机上显示是这样的

![image](https://github.com/user-attachments/assets/f3af0fa9-ddcd-4789-917a-94828727c291)
