### PR TITLE
fix(web): 修复文库标题溢出

### DIFF
--- a/web/src/pages/novel/WenkuNovel.vue
+++ b/web/src/pages/novel/WenkuNovel.vue
@@ -92,7 +92,7 @@ const showWebNovelsModal = ref(false);
               style="border-radius: 2px"
             />
           </div>
-          <n-flex vertical>
+          <n-flex vertical style="min-width: 0">
             <n-h2
               prefix="bar"
               style="margin: 8px 0"


### PR DESCRIPTION
#196 第二部分

Tag过长在小屏幕上会溢出