### PR TITLE
#211 网络小说收藏夹内搜索, Part 1: 网络小说收藏夹上增加"全部"条目

### DIFF
--- a/server/src/main/kotlin/api/RouteUserFavoredWeb.kt
+++ b/server/src/main/kotlin/api/RouteUserFavoredWeb.kt
@@ -12,7 +12,6 @@ import infra.user.UserFavoredRepository
 import infra.web.repository.WebNovelFavoredRepository
 import infra.web.repository.WebNovelMetadataRepository
 import io.ktor.resources.*
-import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.resources.*
 import io.ktor.server.resources.post
@@ -188,20 +187,10 @@ class UserFavoredWebApi(
     ): Page<WebNovelOutlineDto> {
         validatePageNumber(page)
         validatePageSize(pageSize)
-        if (favoredId == "all") {
-            return favoredRepo
-                .listAllFavoredNovels(
-                    userId = user.id,
-                    page = page,
-                    pageSize = pageSize,
-                    sort = sort,
-                )
-                .map { it.asDto() }
-        }
         return favoredRepo
             .listFavoredNovel(
                 userId = user.id,
-                favoredId = favoredId,
+                favoredId = favoredId.takeIf { it != "all" },
                 page = page,
                 pageSize = pageSize,
                 sort = sort,

--- a/server/src/main/kotlin/api/RouteUserFavoredWeb.kt
+++ b/server/src/main/kotlin/api/RouteUserFavoredWeb.kt
@@ -188,6 +188,16 @@ class UserFavoredWebApi(
     ): Page<WebNovelOutlineDto> {
         validatePageNumber(page)
         validatePageSize(pageSize)
+        if (favoredId == "all") {
+            return favoredRepo
+                .listAllFavoredNovels(
+                    userId = user.id,
+                    page = page,
+                    pageSize = pageSize,
+                    sort = sort,
+                )
+                .map { it.asDto() }
+        }
         return favoredRepo
             .listFavoredNovel(
                 userId = user.id,

--- a/server/src/main/kotlin/api/RouteUserFavoredWenku.kt
+++ b/server/src/main/kotlin/api/RouteUserFavoredWenku.kt
@@ -187,7 +187,7 @@ class UserFavoredWenkuApi(
         return favoredRepo
             .listFavoriteWenkuNovel(
                 userId = user.id,
-                favoredId = favoredId,
+                favoredId = favoredId.takeIf { it != "all" },
                 page = page,
                 pageSize = pageSize,
                 sort = sort,

--- a/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
@@ -11,6 +11,7 @@ import infra.*
 import infra.common.FavoredNovelListSort
 import infra.common.Page
 import infra.common.emptyPage
+import infra.web.WebNovelFavoriteDbModel
 import infra.wenku.WenkuNovelFavoriteDbModel
 import infra.wenku.WenkuNovel
 import infra.wenku.WenkuNovelListItem
@@ -46,7 +47,7 @@ class WenkuNovelFavoredRepository(
 
     suspend fun listFavoriteWenkuNovel(
         userId: String,
-        favoredId: String,
+        favoredId: String?,
         page: Int,
         pageSize: Int,
         sort: FavoredNovelListSort,
@@ -57,22 +58,24 @@ class WenkuNovelFavoredRepository(
             val items: List<WenkuNovel>,
         )
 
-        val sortProperty = when (sort) {
-            FavoredNovelListSort.CreateAt -> WenkuNovelFavoriteDbModel::createAt
-            FavoredNovelListSort.UpdateAt -> WenkuNovelFavoriteDbModel::updateAt
+        val filterBson = if (favoredId == null) {
+            eq(WenkuNovelFavoriteDbModel::userId.field(), ObjectId(userId))
+        } else {
+            and(
+                eq(WenkuNovelFavoriteDbModel::userId.field(), ObjectId(userId)),
+                eq(WenkuNovelFavoriteDbModel::favoredId.field(), favoredId),
+            )
+        }
+
+        val sortBson = when (sort) {
+            FavoredNovelListSort.CreateAt -> descending(WenkuNovelFavoriteDbModel::createAt.field())
+            FavoredNovelListSort.UpdateAt -> descending(WenkuNovelFavoriteDbModel::updateAt.field())
         }
 
         val doc = userFavoredWenkuCollection
             .aggregate<PageModel>(
-                match(
-                    and(
-                        eq(WenkuNovelFavoriteDbModel::userId.field(), ObjectId(userId)),
-                        eq(WenkuNovelFavoriteDbModel::favoredId.field(), favoredId),
-                    )
-                ),
-                sort(
-                    descending(sortProperty.field())
-                ),
+                match(filterBson),
+                sort(sortBson),
                 facet(
                     Facet("count", count()),
                     Facet(

--- a/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
@@ -11,7 +11,6 @@ import infra.*
 import infra.common.FavoredNovelListSort
 import infra.common.Page
 import infra.common.emptyPage
-import infra.web.WebNovelFavoriteDbModel
 import infra.wenku.WenkuNovelFavoriteDbModel
 import infra.wenku.WenkuNovel
 import infra.wenku.WenkuNovelListItem

--- a/web/src/pages/bookshelf/components/BookshelfMenu.vue
+++ b/web/src/pages/bookshelf/components/BookshelfMenu.vue
@@ -40,36 +40,34 @@ const menuOptions = computed(() => {
     ),
   };
   if (whoami.value.isSignedIn) {
-    return [
-      {
-        type: 'group',
-        label: '网络小说',
-        children: [
-          menuOption('web', 'all', '全部'),
-          ...favoreds.value.web.map(({ id, title }) =>
-            menuOption('web', id, title),
-          ),
-        ],
-      },
-      {
-        type: 'divider',
-        key: 'divider',
-        props: { style: { marginLeft: '32px' } },
-      },
-      {
-        type: 'group',
-        label: '文库小说',
-        children: favoreds.value.wenku.map(({ id, title }) =>
-          menuOption('wenku', id, title),
-        ),
-      },
-      {
-        type: 'divider',
-        key: 'divider',
-        props: { style: { marginLeft: '32px' } },
-      },
-      localGroup,
-    ];
+    const webGroup = {
+      type: 'group',
+      label: '网络小说',
+      children: favoreds.value.web.map(({ id, title }) =>
+        menuOption('web', id, title),
+      ),
+    };
+    const wenkuGroup = {
+      type: 'group',
+      label: '文库小说',
+      children: favoreds.value.wenku.map(({ id, title }) =>
+        menuOption('wenku', id, title),
+      ),
+    };
+    const divider = {
+      type: 'divider',
+      key: 'divider',
+      props: { style: { marginLeft: '32px' } },
+    };
+
+    if (webGroup.children.length > 1) {
+      webGroup.children.unshift(menuOption('web', 'all', '全部'));
+    }
+    if (wenkuGroup.children.length > 1) {
+      wenkuGroup.children.unshift(menuOption('wenku', 'all', '全部'));
+    }
+
+    return [webGroup, divider, wenkuGroup, divider, localGroup];
   } else {
     return [localGroup];
   }

--- a/web/src/pages/bookshelf/components/BookshelfMenu.vue
+++ b/web/src/pages/bookshelf/components/BookshelfMenu.vue
@@ -44,9 +44,12 @@ const menuOptions = computed(() => {
       {
         type: 'group',
         label: '网络小说',
-        children: favoreds.value.web.map(({ id, title }) =>
-          menuOption('web', id, title),
-        ),
+        children: [
+          menuOption('web', 'all', '全部'),
+          ...favoreds.value.web.map(({ id, title }) =>
+            menuOption('web', id, title),
+          ),
+        ],
       },
       {
         type: 'divider',

--- a/web/src/pages/bookshelf/components/BookshelfMenuItem.vue
+++ b/web/src/pages/bookshelf/components/BookshelfMenuItem.vue
@@ -19,12 +19,15 @@ const store = useBookshelfLocalStore();
 const message = useMessage();
 
 const options =
-  id === 'default'
-    ? [{ label: '编辑信息', key: 'edit' }]
-    : [
-        { label: '编辑信息', key: 'edit' },
-        { label: '删除', key: 'delete' },
-      ];
+  id === 'all'
+    ? []
+    : id === 'default'
+      ? [{ label: '编辑信息', key: 'edit' }]
+      : [
+          { label: '编辑信息', key: 'edit' },
+          { label: '删除', key: 'delete' },
+        ];
+
 const onSelect = (key: string) => {
   if (key === 'edit') {
     showEditModal.value = true;
@@ -94,6 +97,7 @@ const deleteFavored = () =>
     <n-flex align="center" justify="space-between">
       {{ title }}
       <n-dropdown
+        v-if="options.length > 0"
         trigger="hover"
         :options="options"
         :keyboard="false"

--- a/web/src/pages/bookshelf/components/BookshelfMenuItem.vue
+++ b/web/src/pages/bookshelf/components/BookshelfMenuItem.vue
@@ -18,15 +18,20 @@ const store = useBookshelfLocalStore();
 
 const message = useMessage();
 
-const options =
-  id === 'all'
-    ? []
-    : id === 'default'
-      ? [{ label: '编辑信息', key: 'edit' }]
-      : [
-          { label: '编辑信息', key: 'edit' },
-          { label: '删除', key: 'delete' },
-        ];
+const getOptions = () => {
+  if (id === '') {
+    return [];
+  } else if (id === 'default') {
+    return [{ label: '编辑信息', key: 'edit' }];
+  } else {
+    return [
+      { label: '编辑信息', key: 'edit' },
+      { label: '删除', key: 'delete' },
+    ];
+  }
+};
+
+const options = getOptions();
 
 const onSelect = (key: string) => {
   if (key === 'edit') {

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -76,7 +76,7 @@ const router = createRouter({
               props: (route) => ({
                 page: Number(route.query.page) || 1,
                 selected: parseSelected(route.query),
-                favoredId: route.params.favoredId || 'default',
+                favoredId: route.params.favoredId || 'all',
               }),
             },
             {

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -76,7 +76,7 @@ const router = createRouter({
               props: (route) => ({
                 page: Number(route.query.page) || 1,
                 selected: parseSelected(route.query),
-                favoredId: route.params.favoredId || 'all',
+                favoredId: route.params.favoredId || 'default',
               }),
             },
             {


### PR DESCRIPTION
#211 的第一步

在网络小说收藏夹上增加”全部“条目，后续将在此页面添加收藏夹内的搜索功能。
![image](https://github.com/user-attachments/assets/17105e94-5a27-4205-99ec-4caff43dac56)

”全部“的favoredId 为 ”all“
改动了前端UI，增加了后端对于”all”的处理。
后端的函数预计后续合并为统一的根据条件（选定的收藏夹ID，TAG，关键字，更新状态，小说平台）来查询的函数