### PR TITLE
fix(web): 修复分段为空遇到超长行的情况

### DIFF
--- a/web/src/domain/translate/Common.ts
+++ b/web/src/domain/translate/Common.ts
@@ -131,14 +131,16 @@ export const createLengthSegmentor = (
       const lineJpSize = lineJp.length;
 
       if (segSize + lineJpSize > maxLength || segJp.length >= maxLine) {
-        if (textZh === undefined) {
-          segs.push([segJp]);
-        } else {
-          segs.push([segJp, segZh]);
-          segZh = [];
+        if (segJp.length > 0) {
+          if (textZh === undefined) {
+            segs.push([segJp]);
+          } else {
+            segs.push([segJp, segZh]);
+            segZh = [];
+          }
+          segJp = [];
+          segSize = 0;
         }
-        segJp = [];
-        segSize = 0;
       }
 
       if (textZh !== undefined) {


### PR DESCRIPTION
在拆分分段的时候, 如果当前分段为空而下一个遇到的句子是超过长度限制的长行(常见于第一个分段就超了的情况), 那么就会添加一个空分段

而GPT分区的翻译器(比如DeepseekV3)在遇到这种空分段的时候会开始编, 导致行数不匹配完全无法翻译

Sakura分区的会先报错行数不匹配(这时候Sakura会返回一个空字符串), 然后逐行翻译不会检测是否匹配因此能继续进行下去