### PR TITLE
feat: 修改 tsconfig lib 配置，避免一些新函数导致兼容性报错

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -10,17 +10,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "lib": [
-      "ESNext",
-      "DOM"
-    ],
+    "lib": ["ES2021", "DOM"],
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
-    },
+      "@/*": ["src/*"]
+    }
   },
   "include": [
     "auto-imports.d.ts",


### PR DESCRIPTION
修改 lib 配置，可以提前解决像是 1f459c2 这种兼容性问题

ES2021 版本符合 Vite 配置里 build.target 的范围 https://caniuse.com/?search=es2021

![image](https://github.com/user-attachments/assets/63440e31-f1a3-4568-a137-04460bcb5e6c)
