### PR TITLE
fix(epub): fix href parsing in manifest

### DIFF
--- a/server/src/main/kotlin/util/epub/Epub.kt
+++ b/server/src/main/kotlin/util/epub/Epub.kt
@@ -31,7 +31,6 @@ object Epub {
             fs.readFileAsXHtml(opfPath)
                 .select("manifest item[media-type=application/xhtml+xml]")
                 .map { opfDir + "/" + it.attr("href") }
-                .filter { Files.exists(fs.getPath(it)) }
                 .forEach { block(it, fs.readFileAsXHtml(it)) }
         }
     }


### PR DESCRIPTION
Fix when href is a relative path in manifest items (kobo)
Add a custom `util/error.ts` file to provide fine-grained error control.


this fix also modifies `this.resolve` to find the real path as `dir + path,  dir + path with resolve, path`
sample:  [1.zip](https://github.com/user-attachments/files/21115493/1.zip)

