### PR TITLE
feat(web/addon): 使用 Addon fetch 替代 spoofFetch

### DIFF
--- a/web/src/api/third-party/YoudaoApi.ts
+++ b/web/src/api/third-party/YoudaoApi.ts
@@ -18,7 +18,7 @@ const getClient = lazy(async () => {
   const cookies = await ensureCookie(addon, url, domain, keys);
 
   return ky.create({
-    fetch: Addon.fetch.bind(window.Addon),
+    fetch: addon.fetch.bind(window.Addon),
   });
 });
 

--- a/web/src/util/useAddon/index.ts
+++ b/web/src/util/useAddon/index.ts
@@ -7,7 +7,16 @@ export interface CookieStatus {
   sameSite: 'no_restriction' | 'lax' | 'strict' | 'unspecified';
 }
 
+export type InfoResult = {
+  version: string; // extension version
+  homepage_url: string;
+};
+
 export interface AddonApi {
+  ping(): Promise<string>;
+
+  info(): Promise<InfoResult>;
+
   cookiesStatus(params: {
     url?: string;
     domain?: string;


### PR DESCRIPTION
DNR 也能用来修改 extension 端 request 和 response。同时 extension 还能自带 cookies。

同时 spoofFetch 已知存在 `sec-fetch-site: crossXXX`  的问题：
```
sec-fetch-dest: empty
sec-fetch-mode: cors
sec-fetch-site: none
sec-fetch-storage-access: active
```

联动：https://github.com/auto-novel/addon/commit/f3e410a4243bc62e4f362ac5f3d941bb73bd2fbe