### PR TITLE
fix(web): 修复错误处理逻辑以忽略 ResizeObserver 循环错误

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -85,6 +85,10 @@
     <div id="fallback-error" style="position: fixed; height: 100vh"></div>
     <script>
       window.onerror = function (msg, url, line, col) {
+        if (String(msg).includes('ResizeObserver loop')) {
+          return true;
+        }
+
         var div = document.createElement('div');
         div.innerText = `Error: ${line}:${col} ${msg} ${url}`;
         document.getElementById('fallback-error').appendChild(div);


### PR DESCRIPTION
弹性滚动的环境里(苹果系列)下拉会出现这段文字

<img width="1652" height="414" alt="image" src="https://github.com/user-attachments/assets/4ea7923e-7f8f-4943-a02d-8404abf3f31a" />

通常是 ResizeObserver 回调与布局循环产生竞态，浏览器在循环结束时抛出该错误，但多数情况下是“良性”的，不影响功能

所以打算这个错误过滤掉