### PR TITLE
add(web&server) opacity or color

### DIFF
--- a/web/src/api/novel/WebNovelApi.ts
+++ b/web/src/api/novel/WebNovelApi.ts
@@ -10,6 +10,8 @@ import type {
   WebNovelOutlineDto,
 } from '@/model/WebNovel';
 import { client } from './client';
+import { Setting } from '@/stores/useSettingStore';
+import { download } from 'naive-ui/es/_utils';
 
 const listNovel = ({
   page,
@@ -134,6 +136,7 @@ const createFileUrl = ({
   mode,
   translationsMode,
   translations,
+  opacityOrColor,
   type,
   title,
 }: {
@@ -143,6 +146,7 @@ const createFileUrl = ({
   translationsMode: 'parallel' | 'priority';
   translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
   type: 'epub' | 'txt';
+  opacityOrColor: Setting['downloadFormat']['opacityOrColor'];
   title: string;
 }) => {
   const filename = [
@@ -151,6 +155,7 @@ const createFileUrl = ({
       ? ''
       : (translationsMode === 'parallel' ? 'B' : 'Y') +
         translations.map((it) => it[0]).join(''),
+    opacityOrColor === 'opacity' ? 'O' : 'C',
     title.replace(/[\/|\\:*?"<>]/g, ''),
     type,
   ]
@@ -162,6 +167,7 @@ const createFileUrl = ({
     translationsMode,
     type,
     filename,
+    opacityOrColor,
   });
   translations.forEach((it) => params.append('translations', it));
 

--- a/web/src/api/novel/WenkuNovelApi.ts
+++ b/web/src/api/novel/WenkuNovelApi.ts
@@ -10,6 +10,7 @@ import type {
   WenkuVolumeDto,
 } from '@/model/WenkuNovel';
 import { client, uploadFile } from './client';
+import { Setting } from '@/stores/useSettingStore';
 
 const listNovel = ({
   page,
@@ -110,24 +111,28 @@ const createFileUrl = ({
   volumeId,
   mode,
   translationsMode,
+  opacityOrColor,
   translations,
 }: {
   novelId: string;
   volumeId: string;
   mode: 'zh' | 'zh-jp' | 'jp-zh';
   translationsMode: 'parallel' | 'priority';
+  opacityOrColor: Setting['downloadFormat']['opacityOrColor'];
   translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
 }) => {
   const filename = [
     mode,
     (translationsMode === 'parallel' ? 'B' : 'Y') +
       translations.map((it) => it[0]).join(''),
+    opacityOrColor === 'opacity' ? 'O' : 'C',
     volumeId,
   ].join('.');
 
   const params = new URLSearchParams({
     mode,
     translationsMode,
+    opacityOrColor,
     filename,
   });
   translations.forEach((it) => params.append('translations', it));

--- a/web/src/pages/novel/components/TranslateOptions.vue
+++ b/web/src/pages/novel/components/TranslateOptions.vue
@@ -191,6 +191,16 @@ const showDownloadModal = ref(false);
         </c-action-wrapper>
 
         <c-action-wrapper
+          title="使用半透明/浅色字体显示日文原文"
+          v-if="gnid.type === 'web' && setting.downloadFormat.type == 'epub'"
+        >
+          <c-radio-group
+            v-model:value="setting.downloadFormat.opacityOrColor"
+            :options="Setting.epubOpacityOrColorOptions"
+          />
+        </c-action-wrapper>
+
+        <c-action-wrapper
           v-if="gnid.type === 'web'"
           title="中文文件名"
           align="center"

--- a/web/src/pages/novel/components/WebTranslate.vue
+++ b/web/src/pages/novel/components/WebTranslate.vue
@@ -56,7 +56,7 @@ const files = computed(() => {
   const title =
     setting.value.downloadFilenameType === 'jp' ? titleJp : titleZh ?? titleJp;
 
-  const { mode, translationsMode, translations, type } =
+  const { mode, translationsMode, translations, type, opacityOrColor } =
     setting.value.downloadFormat;
 
   return {
@@ -65,6 +65,7 @@ const files = computed(() => {
       novelId,
       mode: 'jp',
       translationsMode,
+      opacityOrColor,
       translations: [],
       type,
       title,
@@ -74,6 +75,7 @@ const files = computed(() => {
       novelId,
       mode: mode,
       translationsMode,
+      opacityOrColor,
       translations,
       type,
       title,

--- a/web/src/pages/novel/components/WenkuVolume.vue
+++ b/web/src/pages/novel/components/WenkuVolume.vue
@@ -36,13 +36,15 @@ const startTranslateTask = (translatorId: 'baidu' | 'youdao') => {
 };
 
 const file = computed(() => {
-  const { mode, translationsMode, translations } = setting.value.downloadFormat;
+  const { mode, translationsMode, translations, opacityOrColor } =
+    setting.value.downloadFormat;
 
   const { url, filename } = WenkuNovelApi.createFileUrl({
     novelId,
     volumeId: volume.volumeId,
     mode,
     translationsMode,
+    opacityOrColor,
     translations,
   });
   return { url, filename };

--- a/web/src/stores/useSettingStore.ts
+++ b/web/src/stores/useSettingStore.ts
@@ -24,6 +24,7 @@ export interface Setting {
     translationsMode: 'parallel' | 'priority';
     translations: TranslatorId[];
     type: 'epub' | 'txt';
+    opacityOrColor: 'opacity' | 'color';
   };
   workspaceSound: boolean;
   paginationMode: 'pagination' | 'scroll';
@@ -59,6 +60,7 @@ export namespace Setting {
       translationsMode: 'priority',
       translations: ['sakura', 'gpt', 'youdao', 'baidu'],
       type: 'epub',
+      opacityOrColor: 'opacity',
     },
     workspaceSound: false,
     paginationMode: 'pagination',
@@ -110,6 +112,11 @@ export namespace Setting {
   export const downloadTypeOptions = [
     { label: 'EPUB', value: 'epub' },
     { label: 'TXT', value: 'txt' },
+  ];
+
+  export const epubOpacityOrColorOptions = [
+    { label: '半透明', value: 'opacity' },
+    { label: '浅色', value: 'color' },
   ];
 
   export const themeOptions = [


### PR DESCRIPTION
添加 epub 下载时选择 opacity or color 选项。

对于某些 reader（比如 koreader）不能渲染透明文本的情况，添加使用浅色的 fallback 。

进度：
- Web：正在写
- Server：还没写

可能的 TODO：
- 允许自定义颜色和透明度
- 允许自定义下划线，背景色，字体，斜体等