### PR TITLE
fix(web): Add responsive vertical layout for translation options in reader settings

### DIFF
--- a/web/src/pages/reader/components/ReaderSettingModal.vue
+++ b/web/src/pages/reader/components/ReaderSettingModal.vue
@@ -32,7 +32,11 @@ const setIndentSize = (diff: number) => {
       style="width: 100%"
     >
       <n-tab-pane name="signin" tab="内容">
-        <n-flex vertical size="large" style="width: 100%; padding: 20px">
+        <n-flex
+          vertical
+          size="large"
+          style="width: 100%; padding: 20px; box-sizing: border-box"
+        >
           <c-action-wrapper title="语言">
             <c-radio-group
               v-model:value="readerSetting.mode"
@@ -40,8 +44,8 @@ const setIndentSize = (diff: number) => {
             />
           </c-action-wrapper>
 
-          <c-action-wrapper title="翻译" align="center">
-            <n-flex size="large" :vertical="!isWideScreen">
+          <c-action-wrapper title="翻译">
+            <n-flex size="large">
               <c-radio-group
                 v-model:value="readerSetting.translationsMode"
                 :options="ReaderSetting.translationModeOptions"


### PR DESCRIPTION
Before:
<img width="332" height="354" alt="截屏2026-01-05 17 07 43" src="https://github.com/user-attachments/assets/fb2a6e9e-dd1c-45fd-9fd5-1cb821bc13ce" />

After:
<img width="459" height="537" alt="截屏2026-01-05 17 08 25" src="https://github.com/user-attachments/assets/f172bbb8-5d7a-4fb4-8961-6ef992f03ea5" />
