### PR TITLE
fix(web): 修正中英文混排情况下的 linkify 解析

### DIFF
--- a/web/src/components/markdown/MarkdownView.vue
+++ b/web/src/components/markdown/MarkdownView.vue
@@ -94,6 +94,35 @@ onMounted(() => {
 
 (() => {
   // 测试页面：https://n.novelia.cc/forum/693160100d2585161e3c68d4
+  // 添加中文分隔符
+  const NEW_SEPARATORS = '）（！？。，【】［］「」、《》★、';
+  const LINKIFY_ORIG_SEPARATORS = '[><\uff5c]'; // 这玩意已经从2023年就没变过了
+  const LINKIFY_NEW_SEPARATORS = `[><\uff5c${NEW_SEPARATORS}]`;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function patchSeparators(linkify: any) {
+    const re = linkify?.re;
+    if (!re) return;
+    for (const key of Object.keys(re)) {
+      const val = re[key];
+      if (typeof val === 'string') {
+        const replaced = val.replaceAll(
+          LINKIFY_ORIG_SEPARATORS,
+          LINKIFY_NEW_SEPARATORS,
+        );
+        if (replaced !== val) re[key] = replaced;
+      } else if (val instanceof RegExp) {
+        const src = val.source;
+        const flags = val.flags ?? undefined;
+        const newSrc = src.replaceAll(
+          LINKIFY_ORIG_SEPARATORS,
+          LINKIFY_NEW_SEPARATORS,
+        );
+        if (newSrc !== src) re[key] = new RegExp(newSrc, flags);
+      }
+    }
+  }
+  patchSeparators(md.linkify);
+
   const entry = ['wenku', 'novel'];
   const providers = [
     'default',


### PR DESCRIPTION
对于 link 紧接着中文标点的情况进行特殊处理

测试页面：https://n.novelia.cc/forum/693160100d2585161e3c68d4
> before
<img width="1210" height="382" alt="image" src="https://github.com/user-attachments/assets/c3503c82-f552-4d40-b562-3c3256a4aabb" />


> after
<img width="1193" height="368" alt="image" src="https://github.com/user-attachments/assets/dcb3eee2-c0e0-4d88-9ea8-e4e5e30ce9be" />
