### PR TITLE
fix(web): 系列頁 ISBN-10 自動解析為 Kindle ASIN

### DIFF
--- a/web/src/domain/smart-import/ApiGetProduct.ts
+++ b/web/src/domain/smart-import/ApiGetProduct.ts
@@ -166,5 +166,17 @@ const parseProductVolume = (doc: Document) => {
   };
 };
 
+export const resolveKindleAsin = async (isbn: string): Promise<string> => {
+  const doc = await AmazonApi.getProduct(isbn);
+  const kindleLink = doc
+    .getElementById('tmm-grid-swatch-KINDLE')
+    ?.querySelector('a');
+  if (kindleLink) {
+    const kindleAsin = extractAsin(kindleLink.getAttribute('href')!);
+    if (kindleAsin) return kindleAsin;
+  }
+  return isbn;
+};
+
 export const getProduct = (asin: string) =>
   AmazonApi.getProduct(asin).then(parseProduct);


### PR DESCRIPTION
## 問題

部分 Amazon 系列頁回傳的是實體書 ISBN-10（純數字）而非 Kindle ASIN（以 "B" 開頭），導致後續 getVolume/getProduct 抓到實體書頁面。

## 修改

- **ApiGetProduct.ts**：新增 `resolveKindleAsin(isbn)`，從實體書頁面的 `#tmm-grid-swatch-KINDLE` 區塊提取 Kindle ASIN，找不到時 fallback 回原始 ISBN
- **ApiGetSerial.ts**：`getSerial` 回傳前以 `Promise.all` 並行將非 "B" 開頭的 ISBN-10 解析為 Kindle ASIN