### PR TITLE
feat(web): 文庫下載無譯文時禁止下載

### DIFF
--- a/web/src/pages/novel/components/WenkuVolume.vue
+++ b/web/src/pages/novel/components/WenkuVolume.vue
@@ -35,6 +35,11 @@ const startTranslateTask = (translatorId: 'baidu' | 'youdao') => {
   );
 };
 
+const hasTranslation = computed(() => {
+  const { translations } = setting.value.downloadFormat;
+  return translations.some((t) => (volume[t] ?? 0) > 0);
+});
+
 const file = computed(() => {
   const { mode, translationsMode, translations } = setting.value.downloadFormat;
 
@@ -129,7 +134,7 @@ const submitJob = (id: 'gpt' | 'sakura') => {
       label="下载"
       :icon="FileDownloadOutlined"
       tag="a"
-      :href="file.url"
+      :href="hasTranslation ? file.url : undefined"
       :download="file.filename"
       target="_blank"
     />


### PR DESCRIPTION
## 改動

當所選翻譯源對該卷的翻譯數量全為 0 時，下載按鈕不觸發下載。

- 新增 `hasTranslation` computed，根據 `setting.downloadFormat.translations` 檢查該卷是否有對應譯文
- 下載按鈕的 `:href` 改為 `hasTranslation ? file.url : undefined`，無譯文時設為 `undefined`

只改動 `web/src/pages/novel/components/WenkuVolume.vue`。