### PR TITLE
feat: 文库小说关联网络小说

### DIFF
--- a/server/src/main/kotlin/api/model/WebNovel.kt
+++ b/server/src/main/kotlin/api/model/WebNovel.kt
@@ -15,6 +15,7 @@ data class WebNovelOutlineDto(
     val attentions: List<WebNovelAttention>,
     val keywords: List<String>,
     val extra: String?,
+    val wenkuId: String?,
     //
     val favored: String?,
     val lastReadAt: Long?,
@@ -38,6 +39,7 @@ fun WebNovelListItem.asDto() =
         attentions = attentions,
         keywords = keywords,
         extra = extra,
+        wenkuId = wenkuId,
         favored = favored,
         lastReadAt = lastReadAt?.epochSeconds,
         total = total,

--- a/server/src/main/kotlin/infra/web/WebNovel.kt
+++ b/server/src/main/kotlin/infra/web/WebNovel.kt
@@ -74,6 +74,7 @@ data class WebNovelListItem(
     val gpt: Long = 0,
     val sakura: Long,
     val extra: String? = null,
+    val wenkuId: String? = null,
     @Contextual val updateAt: Instant? = null,
 )
 

--- a/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
@@ -366,6 +366,7 @@ private fun RemoteNovelListItem.toOutline(
         gpt = novel?.gpt ?: 0,
         sakura = novel?.sakura ?: 0,
         extra = extra,
+        wenkuId = novel?.wenkuId,
         updateAt = novel?.updateAt,
     )
 
@@ -392,6 +393,7 @@ fun WebNovel.toOutline(
         gpt = gpt,
         sakura = sakura,
         extra = null,
+        wenkuId = wenkuId,
         updateAt = updateAt,
     )
 

--- a/web/src/api/novel/WenkuNovelApi.ts
+++ b/web/src/api/novel/WenkuNovelApi.ts
@@ -67,6 +67,9 @@ const createVolume = (
 const deleteVolume = (novelId: string, volumeId: string) =>
   client.delete(`wenku/${novelId}/volume/${encodeURIComponent(volumeId)}`);
 
+const linkWeb = (novelId: string, json: { webIds: string[] }) =>
+  client.put(`wenku/${novelId}/link-web`, { json });
+
 //Translate
 const createTranslationApi = (
   novelId: string,
@@ -147,6 +150,7 @@ export const WenkuNovelApi = {
   updateGlossary,
   createVolume,
   deleteVolume,
+  linkWeb,
   //
   createTranslationApi,
   //

--- a/web/src/model/WebNovel.ts
+++ b/web/src/model/WebNovel.ts
@@ -7,6 +7,7 @@ export interface WebNovelOutlineDto {
   attentions: string[];
   keywords: string[];
   extra?: string;
+  wenkuId?: string;
   //
   favored?: string;
   lastReadAt?: number;

--- a/web/src/repos/useWenkuNovel.ts
+++ b/web/src/repos/useWenkuNovel.ts
@@ -79,4 +79,10 @@ export const WenkuNovelRepo = {
       exact: true,
     }),
   ),
+  linkWeb: withOnSuccess(WenkuNovelApi.linkWeb, (_, novelId) =>
+    cache.invalidateQueries({
+      key: [ItemKey, novelId],
+      exact: true,
+    }),
+  ),
 };


### PR DESCRIPTION
closes #311

## 改動

### Server
- 新增 `PUT /wenku/{novelId}/link-web` endpoint，支援文庫小說關聯/取消關聯網路小說
- 關聯時自動更新雙向引用（wenku 的 webIds 和 web novel 的 wenkuId）
- 若目標 web novel 已關聯其他 wenku，會先從舊 wenku 移除
- Web novel 列表 API 回傳新增 `wenkuId` 欄位

### Frontend
- 文庫小說頁面新增「关联网络小说」按鈕
- 彈窗內可搜索網路小說、勾選/取消勾選、確認關聯
- 搜索結果顯示「已关联本页」/「已关联其他」標籤