### PR TITLE
feat(web+server): 新增 Murasaki 工作区与上传校验链路

### DIFF
--- a/server/src/main/kotlin/api/RouteUserFavoredWeb.kt
+++ b/server/src/main/kotlin/api/RouteUserFavoredWeb.kt
@@ -115,6 +115,7 @@ fun Route.routeUserFavoredWeb() {
                     filterTranslate = when (loc.translate) {
                         1 -> WebNovelFilter.Translate.GPT3
                         2 -> WebNovelFilter.Translate.Sakura
+                        3 -> WebNovelFilter.Translate.Murasaki
                         else -> WebNovelFilter.Translate.全部
                     },
                     filterSort = loc.sort,

--- a/server/src/main/kotlin/api/model/WebNovel.kt
+++ b/server/src/main/kotlin/api/model/WebNovel.kt
@@ -25,6 +25,7 @@ data class WebNovelOutlineDto(
     val youdao: Long,
     val gpt: Long,
     val sakura: Long,
+    val murasaki: Long,
     val updateAt: Long?,
 )
 
@@ -46,6 +47,7 @@ fun WebNovelListItem.asDto() =
         youdao = youdao,
         gpt = gpt,
         sakura = sakura,
+        murasaki = murasaki,
         updateAt = updateAt?.epochSeconds,
     )
 

--- a/server/src/main/kotlin/infra/ElasticSearchClient.kt
+++ b/server/src/main/kotlin/infra/ElasticSearchClient.kt
@@ -29,6 +29,7 @@ fun elasticSearchClient(host: String, port: Int?) =
                         number<Int>("visited")
                         bool("hasGpt")
                         bool("hasSakura")
+                        bool("hasMurasaki")
                         date("updateAt")
                     }
                 }

--- a/server/src/main/kotlin/infra/common/Translation.kt
+++ b/server/src/main/kotlin/infra/common/Translation.kt
@@ -16,6 +16,9 @@ enum class TranslatorId {
 
     @SerialName("sakura")
     Sakura,
+
+    @SerialName("murasaki")
+    Murasaki,
 }
 
 data class Glossary(

--- a/server/src/main/kotlin/infra/web/WebNovel.kt
+++ b/server/src/main/kotlin/infra/web/WebNovel.kt
@@ -19,7 +19,7 @@ object WebNovelFilter {
         val isNsfw get() = this != 一般向
     }
 
-    enum class Translate { 全部, GPT3, Sakura }
+    enum class Translate { 全部, GPT3, Sakura, Murasaki }
     enum class Sort { 更新, 点击, 相关 }
 }
 
@@ -73,6 +73,7 @@ data class WebNovelListItem(
     val youdao: Long = 0,
     val gpt: Long = 0,
     val sakura: Long,
+    val murasaki: Long = 0,
     val extra: String? = null,
     @Contextual val updateAt: Instant? = null,
 )
@@ -103,6 +104,7 @@ class WebNovel(
     val youdao: Long = 0,
     val gpt: Long = 0,
     val sakura: Long = 0,
+    val murasaki: Long = 0,
     // Misc
     val visited: Long = 0,
     val pauseUpdate: Boolean = false,
@@ -163,6 +165,11 @@ data class WebNovelChapter(
     val sakuraGlossaryUuid: String? = null,
     val sakuraGlossary: Map<String, String>? = emptyMap(),
     val sakuraParagraphs: List<String>? = null,
+
+    val murasakiVersion: String? = null,
+    val murasakiGlossaryUuid: String? = null,
+    val murasakiGlossary: Map<String, String>? = emptyMap(),
+    val murasakiParagraphs: List<String>? = null,
 ) {
     companion object {
         fun byId(providerId: String, novelId: String, chapterId: String): Bson {
@@ -188,6 +195,7 @@ data class WebNovelChapterTranslationState(
     val glossaryUuid: String?,
     val translated: Boolean,
     val sakuraVersion: String? = null,
+    val murasakiVersion: String? = null,
 )
 
 // MongoDB

--- a/server/src/main/kotlin/infra/web/datasource/WebNovelEsDataSource.kt
+++ b/server/src/main/kotlin/infra/web/datasource/WebNovelEsDataSource.kt
@@ -32,6 +32,7 @@ class WebNovelEsDataSource(
         val visited: Int,
         val hasGpt: Boolean,
         val hasSakura: Boolean,
+        val hasMurasaki: Boolean = false,
         @Contextual val updateAt: Instant,
     )
 
@@ -92,6 +93,9 @@ class WebNovelEsDataSource(
 
                     WebNovelFilter.Translate.Sakura ->
                         mustQueries.add(ESQuery("term", JsonDsl().apply { put("hasSakura", true) }))
+
+                    WebNovelFilter.Translate.Murasaki ->
+                        mustQueries.add(ESQuery("term", JsonDsl().apply { put("hasMurasaki", true) }))
 
                     else -> Unit
                 }
@@ -190,6 +194,7 @@ class WebNovelEsDataSource(
                 visited = novel.visited.toInt(),
                 hasGpt = novel.gpt > 0,
                 hasSakura = novel.sakura > 0,
+                hasMurasaki = novel.murasaki > 0,
                 updateAt = novel.updateAt,
             ),
             refresh = Refresh.WaitFor,

--- a/server/src/main/kotlin/infra/web/repository/WebNovelChapterRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelChapterRepository.kt
@@ -41,6 +41,7 @@ class WebNovelChapterRepository(
             TranslatorId.Youdao -> Pair(WebNovelChapter::youdaoGlossaryUuid, WebNovelChapter::youdaoParagraphs)
             TranslatorId.Gpt -> Pair(WebNovelChapter::gptGlossaryUuid, WebNovelChapter::gptParagraphs)
             TranslatorId.Sakura -> Pair(WebNovelChapter::sakuraGlossaryUuid, WebNovelChapter::sakuraParagraphs)
+            TranslatorId.Murasaki -> Pair(WebNovelChapter::murasakiGlossaryUuid, WebNovelChapter::murasakiParagraphs)
         }
         return webNovelChapterCollection
             .aggregate<WebNovelChapterTranslationState>(
@@ -49,6 +50,7 @@ class WebNovelChapterRepository(
                     fields(
                         include(
                             WebNovelChapterTranslationState::sakuraVersion.field(),
+                            WebNovelChapterTranslationState::murasakiVersion.field(),
                         ),
                         computed(
                             WebNovelChapterTranslationState::chapterId.field(),
@@ -143,6 +145,9 @@ class WebNovelChapterRepository(
             if (local.sakuraParagraphs != null){
                 updateChapterTranslateState(providerId, novelId, TranslatorId.Sakura)
             }
+            if (local.murasakiParagraphs != null){
+                updateChapterTranslateState(providerId, novelId, TranslatorId.Murasaki)
+            }
             return Result.success(remote)
         } else {
             // 本地存在，且已是最新
@@ -185,6 +190,13 @@ class WebNovelChapterRepository(
                 set(WebNovelChapter::sakuraGlossary.field(), glossaryContent),
                 set(WebNovelChapter::sakuraParagraphs.field(), paragraphsZh)
             )
+
+            TranslatorId.Murasaki -> combine(
+                set(WebNovelChapter::murasakiVersion.field(), "0.2"),
+                set(WebNovelChapter::murasakiGlossaryUuid.field(), glossaryUuid),
+                set(WebNovelChapter::murasakiGlossary.field(), glossaryContent),
+                set(WebNovelChapter::murasakiParagraphs.field(), paragraphsZh)
+            )
         }
         webNovelChapterCollection
             .updateOne(
@@ -209,6 +221,7 @@ class WebNovelChapterRepository(
             TranslatorId.Youdao -> WebNovelChapter::youdaoParagraphs
             TranslatorId.Gpt -> WebNovelChapter::gptParagraphs
             TranslatorId.Sakura -> WebNovelChapter::sakuraParagraphs
+            TranslatorId.Murasaki -> WebNovelChapter::murasakiParagraphs
         }
         val novel = webNovelMetadataCollection.find(WebNovel.byId(providerId, novelId)).firstOrNull()!!
         val chapterIdList = novel.toc.mapNotNull { it.chapterId }
@@ -226,6 +239,7 @@ class WebNovelChapterRepository(
             TranslatorId.Youdao -> WebNovel::youdao
             TranslatorId.Gpt -> WebNovel::gpt
             TranslatorId.Sakura -> WebNovel::sakura
+            TranslatorId.Murasaki -> WebNovel::murasaki
         }
         webNovelMetadataCollection
             .updateOne(

--- a/server/src/main/kotlin/infra/web/repository/WebNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelFavoredRepository.kt
@@ -168,6 +168,7 @@ class WebNovelFavoredRepository(
         when (filterTranslate) {
             WebNovelFilter.Translate.GPT3 -> novelFilters.add(Filters.gt("novel.${WebNovel::gpt.field()}", 0L))
             WebNovelFilter.Translate.Sakura -> novelFilters.add(Filters.gt("novel.${WebNovel::sakura.field()}", 0L))
+            WebNovelFilter.Translate.Murasaki -> novelFilters.add(Filters.gt("novel.${WebNovel::murasaki.field()}", 0L))
             else -> {}
         }
 

--- a/server/src/main/kotlin/infra/web/repository/WebNovelFileRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelFileRepository.kt
@@ -135,6 +135,7 @@ private fun generateWriteInfoFromChapter(
             TranslatorId.Youdao -> chapter.youdaoParagraphs
             TranslatorId.Gpt -> chapter.gptParagraphs
             TranslatorId.Sakura -> chapter.sakuraParagraphs
+            TranslatorId.Murasaki -> chapter.murasakiParagraphs
         }.also {
             if (it == null) missingTranslations.add(id)
         }

--- a/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
@@ -365,6 +365,7 @@ private fun RemoteNovelListItem.toOutline(
         youdao = novel?.youdao ?: 0,
         gpt = novel?.gpt ?: 0,
         sakura = novel?.sakura ?: 0,
+        murasaki = novel?.murasaki ?: 0,
         extra = extra,
         updateAt = novel?.updateAt,
     )
@@ -391,6 +392,7 @@ fun WebNovel.toOutline(
         youdao = youdao,
         gpt = gpt,
         sakura = sakura,
+        murasaki = murasaki,
         extra = null,
         updateAt = updateAt,
     )

--- a/server/src/main/kotlin/infra/web/repository/makeTxt.kt
+++ b/server/src/main/kotlin/infra/web/repository/makeTxt.kt
@@ -58,7 +58,7 @@ private class TxtWriter(
 
     private fun BufferedWriter.writeTranslateStatus(novel: WebNovel){
         with(novel) {
-            write("总计: $jp / 百度: $baidu / 有道: $youdao / GPT: $gpt / Sakura: $sakura")
+            write("总计: $jp / 百度: $baidu / 有道: $youdao / GPT: $gpt / Sakura: $sakura / Murasaki: $murasaki")
         }
     }
 

--- a/server/src/main/kotlin/infra/wenku/WenkuNovel.kt
+++ b/server/src/main/kotlin/infra/wenku/WenkuNovel.kt
@@ -100,13 +100,15 @@ data class WenkuNovelVolumeJp(
     val youdao: Int,
     val gpt: Int,
     val sakura: Int,
+    val murasaki: Int,
 )
 
 @Serializable
 data class WenkuChapterGlossary(
     val uuid: String?,
     val glossary: Map<String, String>,
-    val sakuraVersion: String?,
+    val sakuraVersion: String? = null,
+    val murasakiVersion: String? = null,
 )
 
 // MongoDB

--- a/server/src/main/kotlin/infra/wenku/datasource/WenkuNovelVolumeDiskDataSource.kt
+++ b/server/src/main/kotlin/infra/wenku/datasource/WenkuNovelVolumeDiskDataSource.kt
@@ -49,6 +49,7 @@ class WenkuNovelVolumeDiskDataSource(
                                 youdao = it.listTranslation(TranslatorId.Youdao).size,
                                 gpt = it.listTranslation(TranslatorId.Gpt).size,
                                 sakura = it.listTranslation(TranslatorId.Sakura).size,
+                                murasaki = it.listTranslation(TranslatorId.Murasaki).size,
                             )
                         )
                     } else {
@@ -260,6 +261,7 @@ class VolumeAccessor(val volumesDir: Path, val volumeId: String) {
         glossaryUuid: String?,
         glossary: Map<String, String>,
         sakuraVersion: String?,
+        murasakiVersion: String?,
     ) = setGlossary(
         path = chapterGlossaryPath(
             translatorId = translatorId,
@@ -268,6 +270,7 @@ class VolumeAccessor(val volumesDir: Path, val volumeId: String) {
         glossaryUuid = glossaryUuid,
         glossary = glossary,
         sakuraVersion = sakuraVersion,
+        murasakiVersion = murasakiVersion,
     )
 
 }
@@ -288,6 +291,7 @@ private suspend fun setGlossary(
     glossaryUuid: String?,
     glossary: Map<String, String>,
     sakuraVersion: String?,
+    murasakiVersion: String?,
 ) = withContext(Dispatchers.IO) {
     if (path.parent.notExists()) {
         path.parent.createDirectories()
@@ -297,7 +301,8 @@ private suspend fun setGlossary(
             WenkuChapterGlossary(
                 uuid = glossaryUuid,
                 glossary = glossary,
-                sakuraVersion = sakuraVersion
+                sakuraVersion = sakuraVersion,
+                murasakiVersion = murasakiVersion,
             )
         )
     )

--- a/web/src/api/novel/WebNovelApi.ts
+++ b/web/src/api/novel/WebNovelApi.ts
@@ -111,13 +111,20 @@ const createTranslationApi = (
       glossaryId?: string;
       paragraphsZh: string[];
     },
-  ) =>
-    client
+  ) => {
+    const versionPayload =
+      translatorId === 'sakura'
+        ? { sakuraVersion: '0.9' }
+        : translatorId === 'murasaki'
+          ? { murasakiVersion: '0.2' }
+          : {};
+    return client
       .post(`${endpointV2}/chapter/${chapterId}`, {
-        json: { ...json, sakuraVersion: '0.9' },
+        json: { ...json, ...versionPayload },
         signal,
       })
       .json<{ jp: number; zh: number }>();
+  };
 
   return {
     getTranslateTask,
@@ -141,7 +148,7 @@ const createFileUrl = ({
   novelId: string;
   mode: 'jp' | 'zh' | 'zh-jp' | 'jp-zh';
   translationsMode: 'parallel' | 'priority';
-  translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
+  translations: ('sakura' | 'baidu' | 'youdao' | 'gpt' | 'murasaki')[];
   type: 'epub' | 'txt';
   title: string;
 }) => {

--- a/web/src/api/novel/WenkuNovelApi.ts
+++ b/web/src/api/novel/WenkuNovelApi.ts
@@ -89,13 +89,20 @@ const createTranslationApi = (
   const updateChapterTranslation = (
     chapterId: string,
     json: { glossaryId: string | undefined; paragraphsZh: string[] },
-  ) =>
-    client
+  ) => {
+    const versionPayload =
+      translatorId === 'sakura'
+        ? { sakuraVersion: '0.9' }
+        : translatorId === 'murasaki'
+          ? { murasakiVersion: '0.2' }
+          : {};
+    return client
       .post(`${endpointV2}/chapter/${chapterId}`, {
-        json: { ...json, sakuraVersion: '0.9' },
+        json: { ...json, ...versionPayload },
         signal,
       })
       .json<number>();
+  };
 
   return {
     getTranslateTask,
@@ -116,7 +123,7 @@ const createFileUrl = ({
   volumeId: string;
   mode: 'zh' | 'zh-jp' | 'jp-zh';
   translationsMode: 'parallel' | 'priority';
-  translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
+  translations: ('sakura' | 'baidu' | 'youdao' | 'gpt' | 'murasaki')[];
 }) => {
   const filename = [
     mode,

--- a/web/src/components/TranslateTask.vue
+++ b/web/src/components/TranslateTask.vue
@@ -15,6 +15,7 @@ const emit = defineEmits<{
   'update:youdao': [number];
   'update:gpt': [number];
   'update:sakura': [number];
+  'update:murasaki': [number];
 }>();
 
 const message = useMessage();
@@ -57,6 +58,7 @@ const startTask = async (
       youdao: '有道',
       gpt: 'GPT',
       sakura: 'Sakura',
+      murasaki: 'Murasaki',
     };
     let label = `${idToLaber[translatorDesc.id]}翻译`;
     const suffixParts: string[] = [];
@@ -109,6 +111,8 @@ const startTask = async (
             emit('update:youdao', zh);
           } else if (translatorDesc.id === 'gpt') {
             emit('update:gpt', zh);
+          } else if (translatorDesc.id === 'murasaki') {
+            emit('update:murasaki', zh);
           } else {
             emit('update:sakura', zh);
           }

--- a/web/src/components/TranslatorCheck.vue
+++ b/web/src/components/TranslatorCheck.vue
@@ -15,6 +15,7 @@ const translationOptions: { label: string; value: TranslatorId }[] = [
   { label: '有道', value: 'youdao' },
   { label: 'GPT', value: 'gpt' },
   { label: 'Sakura', value: 'sakura' },
+  { label: 'Murasaki', value: 'murasaki' },
 ];
 
 const toggleTranslator = (id: TranslatorId) => {

--- a/web/src/domain/translate/Common.ts
+++ b/web/src/domain/translate/Common.ts
@@ -177,7 +177,7 @@ export interface SegmentCache {
 }
 
 export const createSegIndexedDbCache = async (
-  storeName: 'gpt-seg-cache' | 'sakura-seg-cache',
+  storeName: 'gpt-seg-cache' | 'sakura-seg-cache' | 'murasaki-seg-cache',
 ) => {
   return <SegmentCache>{
     cacheKey: (seg: string[], extra?: unknown): string =>

--- a/web/src/domain/translate/TranslatorMurasaki.ts
+++ b/web/src/domain/translate/TranslatorMurasaki.ts
@@ -1,0 +1,481 @@
+import { createOpenAiApi } from '@/api/third-party/OpenAiApi';
+import type { Glossary } from '@/model/Glossary';
+
+import type { Logger, SegmentContext, SegmentTranslator } from './Common';
+import { createLengthSegmentor } from './Common';
+
+const THINK_PATTERN_CLOSED = /<think>[\s\S]*?<\/think>/gi;
+const THINK_PATTERN_OPEN = /<think>[\s\S]*?(?:<\/think>|$)/gi;
+const CHINESE_CHAR_PATTERN = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/;
+const LEADING_COMMENT_LINE_PATTERN =
+  /^\s*(?:翻译(?:如下|结果)?|译文(?:如下)?|以下是译文|以下翻译|输出|答案)(?:[:：]\s*)?$/;
+
+export class MurasakiTranslator implements SegmentTranslator {
+  id = <const>'murasaki';
+  log: (message: string, detail?: string[]) => void;
+  private api;
+  version: string = '1.0';
+  model?: {
+    id: string;
+    meta?: MurasakiTranslator.ModelMeta;
+  };
+  segmentor = createLengthSegmentor(1000);
+  segLength = 1000;
+  // Murasaki does not provide cross-segment previous context.
+  prevSegLength = 0;
+
+  constructor(
+    log: Logger,
+    { endpoint, segLength, prevSegLength }: MurasakiTranslator.Config,
+  ) {
+    this.log = log;
+    this.api = createOpenAiApi(endpoint, 'no-key');
+    if (segLength !== undefined) {
+      this.segmentor = createLengthSegmentor(segLength);
+      this.segLength = segLength;
+    }
+    if (prevSegLength !== undefined) {
+      this.prevSegLength = prevSegLength;
+    }
+  }
+
+  async init() {
+    this.model = (await this.detectModel()) as typeof this.model;
+    if (this.model?.id) {
+      this.version = MurasakiTranslator.inferVersion(this.model.id);
+    }
+    console.log('Model:');
+    console.log(this.model);
+    return this;
+  }
+
+  allowUpload = () => {
+    const policy = MurasakiTranslator.uploadPolicy;
+
+    if (
+      policy.enforceSegLength &&
+      this.segLength !== policy.expectedSegLength
+    ) {
+      this.log(`分段长度不是${policy.expectedSegLength}`);
+      return false;
+    }
+    if (
+      policy.enforcePrevSegLength &&
+      this.prevSegLength !== policy.expectedPrevSegLength
+    ) {
+      this.log(`前文长度不是${policy.expectedPrevSegLength}`);
+      return false;
+    }
+
+    if (this.model === undefined) {
+      if (policy.requireModelInfo) {
+        this.log('无法获取模型数据');
+        return false;
+      }
+      this.log('无法获取模型数据，按宽松策略允许上传');
+      return true;
+    }
+
+    const normalizedId = MurasakiTranslator.normalizeModelId(this.model.id);
+    const metaCurrent = this.model.meta ?? {};
+    const allowModel = MurasakiTranslator.allowModels[normalizedId];
+    const inAllowList =
+      allowModel !== undefined ||
+      MurasakiTranslator.allowModelPatterns.some((it) => it.test(normalizedId));
+
+    if (policy.requireModelInAllowList && !inAllowList) {
+      this.log(`模型为${this.model.id}，禁止上传`);
+      return false;
+    }
+
+    if (policy.requireMetaExactMatch && allowModel?.meta) {
+      for (const key in allowModel.meta) {
+        if (metaCurrent[key] !== allowModel.meta[key]) {
+          this.log('模型检查未通过，不要尝试欺骗模型检查');
+          return false;
+        }
+      }
+    }
+
+    this.log(`模型为${this.model.id}，允许上传`);
+    return true;
+  };
+
+  async translate(
+    seg: string[],
+    { glossary, prevSegs, signal }: SegmentContext,
+  ): Promise<string[]> {
+    // Keep original paragraph layout (blank-line counts/positions), but send only
+    // effective text lines to the model using single '\n' separators.
+    const layout = MurasakiTranslator.captureSourceLayout(seg);
+    if (layout.effectiveLines.length === 0) {
+      return seg.map(() => '');
+    }
+
+    const concatedSeg = layout.effectiveLines.join('\n');
+    // Keep previous-context window disabled when prevSegLength <= 0.
+    const prevSegCount =
+      this.prevSegLength <= 0
+        ? 0
+        : -Math.ceil(this.prevSegLength / this.segLength);
+    const concatedPrevSeg =
+      prevSegCount === 0 ? '' : prevSegs.slice(prevSegCount).flat().join('\n');
+
+    let retry = 1;
+    while (retry <= MurasakiTranslator.retryPolicy.segmentRetryLimit) {
+      const { text, hasDegradation } = await this.createChatCompletions(
+        concatedSeg,
+        glossary,
+        concatedPrevSeg,
+        signal,
+      );
+      // Rebuild the original blank-line layout after translation.
+      // If effective-line counts do not match, treat as line mismatch and retry.
+      const splitText = MurasakiTranslator.restoreLinesByLayout(layout, text);
+
+      const linesNotMatched = splitText === undefined;
+      const parts: string[] = [`第${retry}次`];
+      if (hasDegradation) {
+        parts.push('退化');
+      } else if (linesNotMatched) {
+        parts.push('行数不匹配');
+      } else {
+        parts.push('成功');
+      }
+      this.log(parts.join('，'), [seg.join('\n'), text]);
+
+      if (!hasDegradation && splitText !== undefined) {
+        return splitText;
+      }
+      retry += 1;
+    }
+
+    this.log('逐行翻译');
+    let degradationLineCount = 0;
+    const resultPerLine: string[] = [];
+    for (const line of seg) {
+      if (MurasakiTranslator.isBlankLine(line)) {
+        resultPerLine.push('');
+        continue;
+      }
+
+      const { text, hasDegradation } = await this.createChatCompletions(
+        line,
+        glossary,
+        [concatedPrevSeg, ...resultPerLine].join('\n'),
+        signal,
+      );
+      if (hasDegradation) {
+        degradationLineCount += 1;
+        this.log(`单行退化第${degradationLineCount}次`, [line, text]);
+        if (
+          degradationLineCount >=
+          MurasakiTranslator.retryPolicy.perLineDegradationLimit
+        ) {
+          throw Error('单个分段退化次数过多，Murasaki翻译器可能存在异常');
+        }
+        resultPerLine.push(line);
+      } else {
+        resultPerLine.push(MurasakiTranslator.pickSingleLineTranslation(text));
+      }
+    }
+    return resultPerLine;
+  }
+
+  private async detectModel() {
+    const modelsPage = await this.api
+      .listModels({
+        headers: {
+          'ngrok-skip-browser-warning': '69420',
+        },
+      })
+      .catch((e) => {
+        this.log(`获取模型数据失败：${e}`);
+      });
+    const model = modelsPage?.data[0];
+    if (model === undefined) {
+      return undefined;
+    }
+    return {
+      id: MurasakiTranslator.normalizeModelId(model.id),
+      meta: (model.meta ?? undefined) as
+        | MurasakiTranslator.ModelMeta
+        | undefined,
+    };
+  }
+
+  private async createChatCompletions(
+    text: string,
+    glossary: Glossary,
+    prevText: string,
+    signal?: AbortSignal,
+  ) {
+    const messages: {
+      role: 'system' | 'user' | 'assistant';
+      content: string;
+    }[] = [];
+    const system = (content: string) =>
+      messages.push({ role: 'system', content });
+    const user = (content: string) => messages.push({ role: 'user', content });
+    const assistant = (content: string) =>
+      messages.push({ role: 'assistant', content });
+
+    text = text.replace(/[\uff10-\uff19]/g, (ch) =>
+      String.fromCharCode(ch.charCodeAt(0) - 0xfee0),
+    );
+
+    const glossaryHint = MurasakiTranslator.formatGlossary(glossary);
+    if (glossaryHint.length > 0) {
+      system(
+        MurasakiTranslator.NOVEL_SYSTEM_PROMPT_WITH_GLOSSARY.replace(
+          '{glossary}',
+          glossaryHint,
+        ),
+      );
+    } else {
+      system(MurasakiTranslator.NOVEL_SYSTEM_PROMPT);
+    }
+
+    if (prevText !== '') {
+      assistant(prevText);
+    }
+
+    user(`请翻译：\n${text}`);
+
+    const maxNewToken = MurasakiTranslator.defaultSampling.maxTokens;
+    const completion = await this.api.createChatCompletions(
+      {
+        model: '',
+        messages,
+        temperature: MurasakiTranslator.defaultSampling.temperature,
+        top_p: MurasakiTranslator.defaultSampling.topP,
+        max_tokens: maxNewToken,
+        frequency_penalty: MurasakiTranslator.defaultSampling.frequencyPenalty,
+      },
+      {
+        signal,
+        timeout: false,
+      },
+    );
+
+    const completionTokens = completion.usage?.completion_tokens ?? 0;
+    return {
+      text: completion.choices[0].message.content ?? '',
+      hasDegradation: completionTokens >= maxNewToken,
+    };
+  }
+}
+
+export namespace MurasakiTranslator {
+  export interface Config {
+    endpoint: string;
+    segLength?: number;
+    prevSegLength?: number;
+  }
+
+  export const create = (log: Logger, config: Config) =>
+    new MurasakiTranslator(log, config).init();
+
+  export type ModelMetaValue = string | number | boolean;
+  export type ModelMeta = Record<string, ModelMetaValue>;
+  export type AllowModel = {
+    repo: string;
+    file: string;
+    meta?: ModelMeta;
+  };
+
+  export const allowModels: {
+    [key: string]: AllowModel;
+  } = {
+    'murasaki-14b-v0.2-iq4_xs': {
+      repo: 'Murasaki-Project/Murasaki-14B-v0.2-GGUF',
+      file: 'Murasaki-14B-v0.2-IQ4_XS.gguf',
+      meta: {
+        n_vocab: 151936,
+        n_ctx_train: 32768,
+        n_embd: 5120,
+        size: 8104770560,
+      },
+    },
+    'murasaki-14b-v0.2-q6_k': {
+      repo: 'Murasaki-Project/Murasaki-14B-v0.2-GGUF',
+      file: 'Murasaki-14B-v0.2-Q6_K.gguf',
+      meta: {
+        n_vocab: 151936,
+        n_ctx_train: 32768,
+        n_embd: 5120,
+        size: 12121937216,
+      },
+    },
+  };
+
+  export const allowModelPatterns = [
+    /^(murasaki-14b-v0\.2-iq4_xs|murasaki-14b-v0\.2-q6_k)$/i,
+  ];
+
+  export const defaultSampling = {
+    temperature: 0.3,
+    topP: 0.95,
+    frequencyPenalty: 0,
+    maxTokens: 4096,
+  } as const;
+
+  export const retryPolicy = {
+    segmentRetryLimit: 3,
+    perLineDegradationLimit: 2,
+  } as const;
+
+  export const uploadPolicy = {
+    enforceSegLength: true,
+    expectedSegLength: 1000,
+    enforcePrevSegLength: true,
+    expectedPrevSegLength: 0,
+    requireModelInfo: true,
+    requireModelInAllowList: true,
+    requireMetaExactMatch: true,
+  } as const;
+
+  export const NOVEL_SYSTEM_PROMPT = `你是一位精通二次元文化的资深轻小说翻译家。
+请将日文文本翻译成流畅、优美的中文。
+
+**核心要求：**
+1. **深度思考：** 在翻译前，先在 <think> 标签中分析文风、补全主语并梳理逻辑。
+2. **信达雅：** 译文需符合中文轻小说阅读习惯，还原原作的沉浸感与文学性。`;
+
+  export const NOVEL_SYSTEM_PROMPT_WITH_GLOSSARY = `你是一位精通二次元文化的资深轻小说翻译家。
+请将日文文本翻译成流畅、优美的中文。
+
+**核心要求：**
+1. **深度思考：** 在翻译前，先在 <think> 标签中分析文风、补全主语并梳理逻辑。
+2. **信达雅：** 译文需符合中文轻小说阅读习惯，还原原作的沉浸感与文学性。
+
+【术语表】
+{glossary}`;
+
+  export const normalizeModelId = (id: string) =>
+    id
+      .trim()
+      .replace(/(.gguf)$/i, '')
+      .replace(/^Murasaki-Project\//i, '')
+      .toLowerCase();
+
+  export const inferVersion = (id: string) => {
+    const normalized = normalizeModelId(id);
+    const matched = normalized.match(/v(\d+\.\d+)/i);
+    return matched?.[1] ?? '1.0';
+  };
+
+  export const formatGlossary = (glossary: Glossary) => {
+    const entries = Object.entries(glossary).sort(([a], [b]) =>
+      a.localeCompare(b, 'ja-JP'),
+    );
+    if (entries.length === 0) {
+      return '';
+    }
+    return JSON.stringify(Object.fromEntries(entries));
+  };
+
+  export const stripThinkTags = (text: string) => {
+    if (!text) return '';
+
+    const noImEnd = text.replaceAll('<|im_end|>', '').replaceAll('\r\n', '\n');
+    let cleaned = noImEnd.replace(THINK_PATTERN_CLOSED, '');
+    if (cleaned === noImEnd) {
+      cleaned = noImEnd.replace(THINK_PATTERN_OPEN, '');
+    }
+    return cleaned.replace(/<think>|<\/think>/gi, '').trim();
+  };
+
+  export const trimLeadingNoise = (text: string) => {
+    if (!text) return '';
+
+    const lines = text.split('\n');
+    while (lines.length > 0 && LEADING_COMMENT_LINE_PATTERN.test(lines[0])) {
+      lines.shift();
+    }
+
+    const firstChineseLine = lines.findIndex((line) =>
+      CHINESE_CHAR_PATTERN.test(line),
+    );
+    if (firstChineseLine > 0) {
+      return lines.slice(firstChineseLine).join('\n');
+    }
+    return lines.join('\n');
+  };
+
+  export const normalizeTranslatedText = (raw: string) =>
+    trimLeadingNoise(stripThinkTags(raw));
+
+  export const splitTranslatedLines = (raw: string) =>
+    normalizeTranslatedText(raw)
+      .split('\n')
+      .map((line) => line.replace(/\s+$/g, ''));
+
+  export const isBlankLine = (line: string) => line.trim().length === 0;
+
+  export interface SourceLayout {
+    effectiveLines: string[];
+    blankLineCounts: number[];
+  }
+
+  export const captureSourceLayout = (source: string[]): SourceLayout => {
+    // blankLineCounts[i] means: number of blank lines before effectiveLines[i].
+    // The last item stores trailing blank lines after the final effective line.
+    const effectiveLines: string[] = [];
+    const blankLineCounts: number[] = [0];
+
+    for (const line of source) {
+      if (isBlankLine(line)) {
+        blankLineCounts[blankLineCounts.length - 1] += 1;
+      } else {
+        effectiveLines.push(line);
+        blankLineCounts.push(0);
+      }
+    }
+
+    return { effectiveLines, blankLineCounts };
+  };
+
+  export const restoreLinesByLayout = (layout: SourceLayout, raw: string) => {
+    // The model output is normalized, then compared by effective-line count only.
+    // If matched, blank lines are mechanically restored from recorded layout.
+    const translatedLines = splitTranslatedLines(raw);
+    const translatedEffectiveLines = translatedLines.filter(
+      (line) => !isBlankLine(line),
+    );
+    if (translatedEffectiveLines.length !== layout.effectiveLines.length) {
+      return undefined;
+    }
+
+    const aligned: string[] = [];
+    for (let i = 0; i < layout.effectiveLines.length; i += 1) {
+      for (let j = 0; j < layout.blankLineCounts[i]; j += 1) {
+        aligned.push('');
+      }
+      const translated = translatedEffectiveLines[i];
+      if (translated === undefined) {
+        return undefined;
+      }
+      aligned.push(translated);
+    }
+    for (
+      let j = 0;
+      j < layout.blankLineCounts[layout.blankLineCounts.length - 1];
+      j += 1
+    ) {
+      aligned.push('');
+    }
+
+    return aligned;
+  };
+
+  export const pickSingleLineTranslation = (raw: string) => {
+    const lines = splitTranslatedLines(raw).filter(
+      (line) => line.trim().length > 0,
+    );
+    if (lines.length === 0) {
+      return '';
+    }
+    return lines[0];
+  };
+}

--- a/web/src/domain/translate/index.ts
+++ b/web/src/domain/translate/index.ts
@@ -3,3 +3,4 @@ export { Translator } from './Translator';
 export type { TranslatorConfig } from './Translator';
 
 export { SakuraTranslator } from './TranslatorSakura';
+export { MurasakiTranslator } from './TranslatorMurasaki';

--- a/web/src/model/LocalVolume.ts
+++ b/web/src/model/LocalVolume.ts
@@ -16,6 +16,7 @@ export interface LocalVolumeMetadata {
     youdao?: string;
     gpt?: string;
     sakura?: string;
+    murasaki?: string;
   }[];
   glossaryId: string;
   glossary: Glossary;
@@ -30,4 +31,5 @@ export interface LocalVolumeChapter {
   youdao?: ChapterTranslation;
   gpt?: ChapterTranslation;
   sakura?: ChapterTranslation;
+  murasaki?: ChapterTranslation;
 }

--- a/web/src/model/Translator.ts
+++ b/web/src/model/Translator.ts
@@ -1,6 +1,6 @@
 import type { Glossary } from './Glossary';
 
-export type TranslatorId = 'sakura' | 'baidu' | 'youdao' | 'gpt';
+export type TranslatorId = 'sakura' | 'baidu' | 'youdao' | 'gpt' | 'murasaki';
 
 export interface GptWorker {
   id: string;
@@ -11,6 +11,13 @@ export interface GptWorker {
 }
 
 export interface SakuraWorker {
+  id: string;
+  endpoint: string;
+  segLength?: number;
+  prevSegLength?: number;
+}
+
+export interface MurasakiWorker {
   id: string;
   endpoint: string;
   segLength?: number;

--- a/web/src/model/WebNovel.ts
+++ b/web/src/model/WebNovel.ts
@@ -17,6 +17,7 @@ export interface WebNovelOutlineDto {
   youdao: number;
   gpt: number;
   sakura: number;
+  murasaki: number;
   updateAt?: number;
 }
 
@@ -50,6 +51,7 @@ export interface WebNovelDto {
   youdao: number;
   gpt: number;
   sakura: number;
+  murasaki: number;
 }
 
 export interface WebNovelChapterDto {
@@ -62,4 +64,5 @@ export interface WebNovelChapterDto {
   youdaoParagraphs?: string[];
   gptParagraphs?: string[];
   sakuraParagraphs?: string[];
+  murasakiParagraphs?: string[];
 }

--- a/web/src/model/WenkuNovel.ts
+++ b/web/src/model/WenkuNovel.ts
@@ -45,6 +45,7 @@ export interface VolumeJpDto {
   youdao: number;
   gpt: number;
   sakura: number;
+  murasaki: number;
 }
 
 export interface AmazonNovel {

--- a/web/src/pages/MainLayout.vue
+++ b/web/src/pages/MainLayout.vue
@@ -140,6 +140,10 @@ const menuOptions = computed<MenuOption[]>(() => {
           key: '/workspace/sakura',
         },
         {
+          label: renderLabel('Murasaki工作区', '/workspace/murasaki'),
+          key: '/workspace/murasaki',
+        },
+        {
           label: renderLabel('交互翻译', '/workspace/interactive'),
           key: '/workspace/interactive',
         },

--- a/web/src/pages/bookshelf/BookshelfLocalStore.ts
+++ b/web/src/pages/bookshelf/BookshelfLocalStore.ts
@@ -134,7 +134,7 @@ export const useBookshelfLocalStore = defineStore('BookshelfLocal', {
         total,
       }: {
         level: 'expire' | 'all' | 'normal' | 'sync';
-        type: 'gpt' | 'sakura';
+        type: 'gpt' | 'sakura' | 'murasaki';
         shouldTop: boolean;
         startIndex: number;
         endIndex: number;
@@ -190,7 +190,7 @@ export const useBookshelfLocalStore = defineStore('BookshelfLocal', {
         shouldTop,
       }: {
         level: 'expire' | 'all';
-        type: 'gpt' | 'sakura';
+        type: 'gpt' | 'sakura' | 'murasaki';
         shouldTop: boolean;
       },
     ) {

--- a/web/src/pages/bookshelf/components/BookshelfLocalControl.vue
+++ b/web/src/pages/bookshelf/components/BookshelfLocalControl.vue
@@ -110,7 +110,7 @@ const translateLevel = ref<'expire' | 'all'>('expire');
 const reverseOrder = ref(false);
 const shouldTopJob = useKeyModifier('Control');
 
-const queueJobs = (type: 'gpt' | 'sakura') => {
+const queueJobs = (type: 'gpt' | 'sakura' | 'murasaki') => {
   let ids = props.selectedIds;
   if (ids.length === 0) {
     message.info('没有选中小说');
@@ -221,7 +221,8 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
     <n-list-item
       v-if="
         setting.enabledTranslator.includes('gpt') ||
-        setting.enabledTranslator.includes('sakura')
+        setting.enabledTranslator.includes('sakura') ||
+        setting.enabledTranslator.includes('murasaki')
       "
     >
       <n-flex vertical>
@@ -268,6 +269,12 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
               label="排队Sakura"
               :round="false"
               @action="queueJobs('sakura')"
+            />
+            <c-button
+              v-if="setting.enabledTranslator.includes('murasaki')"
+              label="排队Murasaki"
+              :round="false"
+              @action="queueJobs('murasaki')"
             />
           </n-button-group>
         </c-action-wrapper>

--- a/web/src/pages/bookshelf/components/BookshelfLocalListItem.vue
+++ b/web/src/pages/bookshelf/components/BookshelfLocalListItem.vue
@@ -18,6 +18,7 @@ const baidu = ref(calculateFinished('baidu'));
 const youdao = ref(calculateFinished('youdao'));
 const gpt = ref(calculateFinished('gpt'));
 const sakura = ref(calculateFinished('sakura'));
+const murasaki = ref(calculateFinished('murasaki'));
 
 const translateTask = useTemplateRef('translateTask');
 const startTranslateTask = (translatorId: 'baidu' | 'youdao') =>
@@ -45,7 +46,7 @@ const startTranslateTask = (translatorId: 'baidu' | 'youdao') =>
 
     <n-text depth="3">
       总计 {{ volume.toc.length }} / 百度 {{ baidu }} / 有道 {{ youdao }} / GPT
-      {{ gpt }} / Sakura {{ sakura }}
+      {{ gpt }} / Sakura {{ sakura }} / Murasaki {{ murasaki }}
     </n-text>
 
     <n-flex :size="8">

--- a/web/src/pages/bookshelf/components/BookshelfWebControl.vue
+++ b/web/src/pages/bookshelf/components/BookshelfWebControl.vue
@@ -94,7 +94,7 @@ const first5 = ref(false);
 const reverseOrder = ref(false);
 const shouldTopJob = useKeyModifier('Control');
 
-const queueJobs = (type: 'gpt' | 'sakura') => {
+const queueJobs = (type: 'gpt' | 'sakura' | 'murasaki') => {
   let novels = props.selectedNovels;
   if (novels.length === 0) {
     message.info('没有选中小说');
@@ -206,7 +206,8 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
     <n-list-item
       v-if="
         setting.enabledTranslator.includes('gpt') ||
-        setting.enabledTranslator.includes('sakura')
+        setting.enabledTranslator.includes('sakura') ||
+        setting.enabledTranslator.includes('murasaki')
       "
     >
       <n-flex vertical>
@@ -267,6 +268,12 @@ const queueJobs = (type: 'gpt' | 'sakura') => {
             label="排队Sakura"
             :round="false"
             @action="queueJobs('sakura')"
+          />
+          <c-button
+            v-if="setting.enabledTranslator.includes('murasaki')"
+            label="排队Murasaki"
+            :round="false"
+            @action="queueJobs('murasaki')"
           />
         </n-button-group>
       </n-flex>

--- a/web/src/pages/bookshelf/option.ts
+++ b/web/src/pages/bookshelf/option.ts
@@ -51,7 +51,7 @@ export function getWebFavoredListOptions(
     },
     翻译: {
       type: 'select',
-      tags: ['全部', 'GPT', 'Sakura'],
+      tags: ['全部', 'GPT', 'Sakura', 'Murasaki'],
     },
     排序: {
       type: 'select',

--- a/web/src/pages/home/components/PanelWebNovel.vue
+++ b/web/src/pages/home/components/PanelWebNovel.vue
@@ -24,7 +24,8 @@ defineProps<{
         <n-text depth="3">
           {{ item.type }} / 总计 {{ item.total }} / 百度 {{ item.baidu }}
           <br />
-          有道 {{ item.youdao }} / GPT {{ item.gpt }} / Sakura {{ item.sakura }}
+          有道 {{ item.youdao }} / GPT {{ item.gpt }} / Sakura
+          {{ item.sakura }} / Murasaki {{ item.murasaki }}
         </n-text>
       </n-grid-item>
     </n-grid>

--- a/web/src/pages/list/components/NovelListWeb.vue
+++ b/web/src/pages/list/components/NovelListWeb.vue
@@ -131,6 +131,7 @@ defineExpose({
           {{ item.type ? item.type + ' / ' : '' }}
           总计 {{ item.total }} / 百度 {{ item.baidu }} / 有道
           {{ item.youdao }} / GPT {{ item.gpt }} / Sakura {{ item.sakura }} /
+          Murasaki {{ item.murasaki }} /
         </n-text>
 
         <n-text depth="3">

--- a/web/src/pages/list/option.ts
+++ b/web/src/pages/list/option.ts
@@ -71,7 +71,7 @@ export function getWebListOptions(allowNsfw: boolean): WebListOptions {
     },
     翻译: {
       type: 'select',
-      tags: ['全部', 'GPT', 'Sakura'],
+      tags: ['全部', 'GPT', 'Sakura', 'Murasaki'],
     },
     排序: {
       type: 'select',

--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -63,6 +63,7 @@ const { expandedNames, hasSeparators, isAnyExpanded, toggleAll, tocSections } =
     v-model:youdao="novel.youdao"
     v-model:gpt="novel.gpt"
     :sakura="novel.sakura"
+    :murasaki="novel.murasaki"
     :glossary="novel.glossary"
   />
 

--- a/web/src/pages/novel/components/WebNovelWide.vue
+++ b/web/src/pages/novel/components/WebNovelWide.vue
@@ -56,6 +56,7 @@ const { expandedNames, hasSeparators, isAnyExpanded, toggleAll, tocSections } =
       v-model:youdao="novel.youdao"
       v-model:gpt="novel.gpt"
       :sakura="novel.sakura"
+      :murasaki="novel.murasaki"
       :glossary="novel.glossary"
     />
 

--- a/web/src/pages/novel/components/WebTranslate.vue
+++ b/web/src/pages/novel/components/WebTranslate.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
   youdao: number;
   gpt: number;
   sakura: number;
+  murasaki: number;
   glossary: { [key: string]: string };
 }>();
 
@@ -33,6 +34,7 @@ const emit = defineEmits<{
   'update:baidu': [number];
   'update:youdao': [number];
   'update:gpt': [number];
+  'update:murasaki': [number];
 }>();
 
 const message = useMessage();
@@ -94,7 +96,7 @@ const importToWorkspace = async () => {
 };
 
 const pressControl = useKeyModifier('Control');
-const submitJob = (id: 'gpt' | 'sakura') => {
+const submitJob = (id: 'gpt' | 'sakura' | 'murasaki') => {
   const { startIndex, endIndex, level, forceMetadata } =
     translateOptions.value!.getTranslateTaskParams();
   const taskNumber = translateOptions.value!.getTaskNumber();
@@ -169,7 +171,7 @@ const submitJob = (id: 'gpt' | 'sakura') => {
   <n-flex vertical style="margin-top: 16px">
     <n-text>
       总计 {{ total }} / 百度 {{ baidu }} / 有道 {{ youdao }} / GPT {{ gpt }} /
-      Sakura {{ sakura }}
+      Sakura {{ sakura }} / Murasaki {{ murasaki }}
     </n-text>
 
     <template v-if="whoami.isSignedIn && setting.enabledTranslator.length > 0">
@@ -197,6 +199,12 @@ const submitJob = (id: 'gpt' | 'sakura') => {
           label="排队Sakura"
           :round="false"
           @action="submitJob('sakura')"
+        />
+        <c-button
+          v-if="setting.enabledTranslator.includes('murasaki')"
+          label="排队Murasaki"
+          :round="false"
+          @action="submitJob('murasaki')"
         />
       </n-button-group>
     </template>
@@ -232,6 +240,7 @@ const submitJob = (id: 'gpt' | 'sakura') => {
     @update:baidu="(zh) => emit('update:baidu', zh)"
     @update:youdao="(zh) => emit('update:youdao', zh)"
     @update:gpt="(zh) => emit('update:gpt', zh)"
+    @update:murasaki="(zh) => emit('update:murasaki', zh)"
     style="margin-top: 20px"
   />
 </template>

--- a/web/src/pages/novel/components/WenkuVolume.vue
+++ b/web/src/pages/novel/components/WenkuVolume.vue
@@ -49,7 +49,7 @@ const file = computed(() => {
 });
 
 const shouldTopJob = useKeyModifier('Control');
-const submitJob = (id: 'gpt' | 'sakura') => {
+const submitJob = (id: 'gpt' | 'sakura' | 'murasaki') => {
   const task = TranslateTaskDescriptor.wenku(
     novelId,
     volume.volumeId,
@@ -80,7 +80,8 @@ const submitJob = (id: 'gpt' | 'sakura') => {
 
       <n-text depth="3">
         总计 {{ volume.total }} / 百度 {{ volume.baidu }} / 有道
-        {{ volume.youdao }} / GPT {{ volume.gpt }} / Sakura {{ volume.sakura }}
+        {{ volume.youdao }} / GPT {{ volume.gpt }} / Sakura
+        {{ volume.sakura }} / Murasaki {{ volume.murasaki }}
       </n-text>
 
       <n-flex :size="8">
@@ -113,6 +114,13 @@ const submitJob = (id: 'gpt' | 'sakura') => {
           secondary
           @action="submitJob('sakura')"
         />
+        <c-button
+          v-if="setting.enabledTranslator.includes('murasaki')"
+          label="排队Murasaki"
+          size="tiny"
+          secondary
+          @action="submitJob('murasaki')"
+        />
         <c-button-confirm
           v-if="whoami.asAdmin"
           :hint="`真的要删除《${volume.volumeId}》吗？`"
@@ -141,6 +149,7 @@ const submitJob = (id: 'gpt' | 'sakura') => {
     @update:youdao="(zh) => (volume.youdao = zh)"
     @update:gpt="(zh) => (volume.gpt = zh)"
     @update:sakura="(zh) => (volume.sakura = zh)"
+    @update:murasaki="(zh) => (volume.murasaki = zh)"
     style="margin-top: 20px"
   />
 </template>

--- a/web/src/pages/other/Setting.vue
+++ b/web/src/pages/other/Setting.vue
@@ -49,9 +49,11 @@ const playSound = (source: string) => {
           <b>快捷键说明</b>
           <n-ul>
             <n-li>列表页面，可以使用左右方向键翻页。</n-li>
-            <n-li>GPT/Sakura排队按钮，按住Ctrl键点击，会将任务自动置顶。</n-li>
+            <n-li>
+              GPT/Sakura/Murasaki排队按钮，按住Ctrl键点击，会将任务自动置顶。
+            </n-li>
             <n-li>阅读页面，可以使用左右方向键跳转上/下一章。</n-li>
-            <n-li>阅读页面，可以使用数字键1～4快速切换翻译。</n-li>
+            <n-li>阅读页面，可以使用数字键1～5快速切换翻译。</n-li>
           </n-ul>
         </n-flex>
       </n-list-item>

--- a/web/src/pages/reader/Reader.vue
+++ b/web/src/pages/reader/Reader.vue
@@ -228,7 +228,7 @@ onKeyDown(['ArrowRight'], (e) => {
   }
 });
 
-onKeyDown(['1', '2', '3', '4'], (e) => {
+onKeyDown(['1', '2', '3', '4', '5'], (e) => {
   if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) {
     return;
   }
@@ -236,7 +236,13 @@ onKeyDown(['1', '2', '3', '4'], (e) => {
     return;
   }
   const setting = readerSetting.value;
-  const translatorIds = <TranslatorId[]>['baidu', 'youdao', 'gpt', 'sakura'];
+  const translatorIds = <TranslatorId[]>[
+    'baidu',
+    'youdao',
+    'gpt',
+    'sakura',
+    'murasaki',
+  ];
   const translatorId = translatorIds[parseInt(e.key, 10) - 1];
   if (setting.translationsMode === 'parallel') {
     if (setting.translations.includes(translatorId)) {

--- a/web/src/pages/reader/ReaderStore.ts
+++ b/web/src/pages/reader/ReaderStore.ts
@@ -15,6 +15,7 @@ export interface ReaderChapter {
   youdaoParagraphs?: string[];
   gptParagraphs?: string[];
   sakuraParagraphs?: string[];
+  murasakiParagraphs?: string[];
 }
 
 interface ReaderChapterState {
@@ -106,6 +107,7 @@ const getChapter = async (
       youdaoParagraphs: chapter.youdao?.paragraphs,
       gptParagraphs: chapter.gpt?.paragraphs,
       sakuraParagraphs: chapter.sakura?.paragraphs,
+      murasakiParagraphs: chapter.murasaki?.paragraphs,
     };
   }
 };

--- a/web/src/pages/reader/components/BuildParagraphs.ts
+++ b/web/src/pages/reader/components/BuildParagraphs.ts
@@ -59,6 +59,8 @@ export const buildParagraphs = (
         return ['百度', chapter.baiduParagraphs];
       } else if (t === 'gpt') {
         return ['GPT', chapter.gptParagraphs];
+      } else if (t === 'murasaki') {
+        return ['Murasaki', chapter.murasakiParagraphs];
       } else {
         return ['Sakura', chapter.sakuraParagraphs];
       }

--- a/web/src/pages/workspace/MurasakiWorkspace.vue
+++ b/web/src/pages/workspace/MurasakiWorkspace.vue
@@ -1,0 +1,204 @@
+<script lang="ts" setup>
+import {
+  BookOutlined,
+  DeleteOutlineOutlined,
+  PlusOutlined,
+} from '@vicons/material';
+import { VueDraggable } from 'vue-draggable-plus';
+
+import { MurasakiTranslator } from '@/domain/translate';
+import { TranslationCacheRepo } from '@/repos';
+import type { TranslateJob } from '@/model/Translator';
+import { doAction } from '@/pages/util';
+import SoundAllTaskCompleted from '@/sound/all_task_completed.mp3';
+import { useMurasakiWorkspaceStore, useSettingStore } from '@/stores';
+
+const message = useMessage();
+
+const settingStore = useSettingStore();
+const { setting } = storeToRefs(settingStore);
+
+const workspace = useMurasakiWorkspaceStore();
+const workspaceRef = workspace.ref;
+
+const showCreateWorkerModal = ref(false);
+const showLocalVolumeDrawer = ref(false);
+
+type ProcessedJob = TranslateJob & {
+  progress?: { finished: number; error: number; total: number };
+};
+
+const processedJobs = ref<Map<string, ProcessedJob>>(new Map());
+
+const getNextJob = () => {
+  const job = workspaceRef.value.jobs.find(
+    (it) => !processedJobs.value.has(it.task),
+  );
+  if (job !== undefined) {
+    processedJobs.value.set(job.task, job);
+  } else if (processedJobs.value.size === 0 && setting.value.workspaceSound) {
+    new Audio(SoundAllTaskCompleted).play();
+  }
+  return job;
+};
+
+const deleteJob = (task: string) => {
+  if (processedJobs.value.has(task)) {
+    message.error('任务被翻译器占用');
+    return;
+  }
+  workspace.deleteJob(task);
+};
+const deleteAllJobs = () => {
+  workspaceRef.value.jobs.forEach((job) => {
+    if (processedJobs.value.has(job.task)) {
+      return;
+    }
+    workspace.deleteJob(job.task);
+  });
+};
+
+const onProgressUpdated = (
+  task: string,
+  state:
+    | { state: 'finish'; abort: boolean }
+    | { state: 'processed'; finished: number; error: number; total: number },
+) => {
+  if (state.state === 'finish') {
+    const job = processedJobs.value.get(task)!;
+    processedJobs.value.delete(task);
+    if (!state.abort) {
+      job.finishAt = Date.now();
+      workspace.addJobRecord(job as TranslateJob);
+      workspace.deleteJob(task);
+    }
+  } else {
+    const job = processedJobs.value.get(task)!;
+    job.progress = {
+      finished: state.finished,
+      error: state.error,
+      total: state.total,
+    };
+  }
+};
+
+const clearCache = async () =>
+  doAction(
+    TranslationCacheRepo.clear('murasaki-seg-cache'),
+    '缓存清除',
+    message,
+  );
+</script>
+
+<template>
+  <div class="layout-content">
+    <n-h1>Murasaki工作区</n-h1>
+
+    <bulletin>
+      <n-p>
+        Murasaki是一款基于Sakura-qwen3-base微调的带有思维链的翻译模型，拥有更好的上下文理解能力。目前正在测试中。
+      </n-p>
+      <n-p>允许上传的模型如下，禁止一切试图突破上传检查的操作。</n-p>
+      <n-ul>
+        <n-li
+          v-for="({ repo, file }, model) in MurasakiTranslator.allowModels"
+          :key="model"
+        >
+          <template v-if="repo !== 'local'">
+            [
+            <n-a
+              target="_blank"
+              :href="`https://huggingface.co/${repo}/blob/main/${file}`"
+            >
+              HF
+            </n-a>
+            /
+            <n-a
+              target="_blank"
+              :href="`https://hf-mirror.com/${repo}/blob/main/${file}`"
+            >
+              国内镜像
+            </n-a>
+            ]
+          </template>
+          {{ model }}
+        </n-li>
+      </n-ul>
+    </bulletin>
+
+    <section-header title="翻译器">
+      <c-button
+        label="添加翻译器"
+        :icon="PlusOutlined"
+        @action="showCreateWorkerModal = true"
+      />
+      <c-button-confirm
+        hint="真的要清空缓存吗？"
+        label="清空缓存"
+        :icon="DeleteOutlineOutlined"
+        @action="clearCache"
+      />
+    </section-header>
+
+    <n-empty
+      v-if="workspaceRef.workers.length === 0"
+      description="没有翻译器"
+    />
+    <n-list>
+      <vue-draggable
+        v-model="workspaceRef.workers"
+        :animation="150"
+        handle=".drag-trigger"
+      >
+        <n-list-item v-for="worker of workspaceRef.workers" :key="worker.id">
+          <job-worker
+            :worker="{ translatorId: 'murasaki', ...worker }"
+            :get-next-job="getNextJob"
+            @update:progress="onProgressUpdated"
+          />
+        </n-list-item>
+      </vue-draggable>
+    </n-list>
+
+    <section-header title="任务队列">
+      <c-button
+        label="本地书架"
+        :icon="BookOutlined"
+        @action="showLocalVolumeDrawer = true"
+      />
+      <c-button-confirm
+        hint="真的要清空队列吗？"
+        label="清空队列"
+        :icon="DeleteOutlineOutlined"
+        @action="deleteAllJobs"
+      />
+    </section-header>
+    <n-empty v-if="workspaceRef.jobs.length === 0" description="没有任务" />
+    <n-list>
+      <vue-draggable
+        v-model="workspaceRef.jobs"
+        :animation="150"
+        handle=".drag-trigger"
+      >
+        <n-list-item v-for="job of workspaceRef.jobs" :key="job.task">
+          <job-queue
+            :job="job"
+            :progress="processedJobs.get(job.task)?.progress"
+            @top-job="workspace.topJob(job)"
+            @bottom-job="workspace.bottomJob(job)"
+            @delete-job="deleteJob(job.task)"
+          />
+        </n-list-item>
+      </vue-draggable>
+    </n-list>
+
+    <job-record-section id="murasaki" />
+  </div>
+
+  <local-volume-list-specific-translation
+    v-model:show="showLocalVolumeDrawer"
+    type="murasaki"
+  />
+
+  <murasaki-worker-modal v-model:show="showCreateWorkerModal" />
+</template>

--- a/web/src/pages/workspace/components/JobRecordSection.vue
+++ b/web/src/pages/workspace/components/JobRecordSection.vue
@@ -10,7 +10,7 @@ import { useBookshelfLocalStore } from '@/pages/bookshelf/BookshelfLocalStore';
 import { useWorkspaceStore } from '@/stores';
 
 const props = defineProps<{
-  id: 'gpt' | 'sakura';
+  id: 'gpt' | 'sakura' | 'murasaki';
 }>();
 
 const message = useMessage();

--- a/web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue
+++ b/web/src/pages/workspace/components/LocalVolumeListSpecificTranslation.vue
@@ -12,7 +12,7 @@ import { downloadFile } from '@/util';
 const translateOptions = useTemplateRef('translateOptions');
 
 const props = defineProps<{
-  type: 'gpt' | 'sakura';
+  type: 'gpt' | 'sakura' | 'murasaki';
 }>();
 
 const message = useMessage();
@@ -30,6 +30,8 @@ const calculateFinished = (volume: LocalVolumeMetadata) =>
     let chapterGlossaryId: string | undefined;
     if (props.type === 'gpt') {
       chapterGlossaryId = it.gpt;
+    } else if (props.type === 'murasaki') {
+      chapterGlossaryId = it.murasaki;
     } else {
       chapterGlossaryId = it.sakura;
     }
@@ -41,6 +43,8 @@ const calculateExpired = (volume: LocalVolumeMetadata) =>
     let chapterGlossaryId: string | undefined;
     if (props.type === 'gpt') {
       chapterGlossaryId = it.gpt;
+    } else if (props.type === 'murasaki') {
+      chapterGlossaryId = it.murasaki;
     } else {
       chapterGlossaryId = it.sakura;
     }

--- a/web/src/pages/workspace/components/MurasakiWorkerModal.vue
+++ b/web/src/pages/workspace/components/MurasakiWorkerModal.vue
@@ -1,0 +1,144 @@
+<script lang="ts" setup>
+import type { FormInst, FormItemRule, FormRules } from 'naive-ui';
+
+import type { MurasakiWorker } from '@/model/Translator';
+import { useMurasakiWorkspaceStore } from '@/stores';
+
+const props = defineProps<{
+  show: boolean;
+  worker?: MurasakiWorker;
+}>();
+const emit = defineEmits<{
+  'update:show': [boolean];
+}>();
+
+const workspace = useMurasakiWorkspaceStore();
+const workspaceRef = workspace.ref;
+
+const initFormValue = () => {
+  const worker = props.worker;
+  if (worker === undefined) {
+    return {
+      id: '',
+      endpoint: '',
+      segLength: 1000,
+      prevSegLength: 0,
+    };
+  } else {
+    return {
+      id: worker.id,
+      endpoint: worker.endpoint,
+      segLength: worker.segLength ?? 1000,
+      prevSegLength: worker.prevSegLength ?? 0,
+    };
+  }
+};
+
+const formRef = useTemplateRef<FormInst>('form');
+const formValue = ref(initFormValue());
+const formRules: FormRules = {
+  id: [
+    {
+      validator: (rule: FormItemRule, value: string) => value.trim().length > 0,
+      message: '名字不能为空',
+      trigger: 'input',
+    },
+    {
+      validator: (rule: FormItemRule, value: string) =>
+        workspaceRef.value.workers
+          .filter(({ id }) => id !== props.worker?.id)
+          .find(({ id }) => id === value) === undefined,
+      message: '名字不能重复',
+      trigger: 'input',
+    },
+  ],
+  endpoint: [
+    {
+      validator: (rule: FormItemRule, value: string) => value.trim().length > 0,
+      message: '链接不能为空',
+      trigger: 'input',
+    },
+    {
+      validator: (rule: FormItemRule, value: string) => {
+        try {
+          const url = new URL(value);
+          return url.protocol === 'http:' || url.protocol === 'https:';
+        } catch (_) {
+          return false;
+        }
+      },
+      message: '链接不合法',
+      trigger: 'input',
+    },
+  ],
+};
+
+const submit = async () => {
+  const validated = await new Promise<boolean>(function (resolve, _reject) {
+    formRef.value?.validate((errors) => {
+      if (errors) resolve(false);
+      else resolve(true);
+    });
+  });
+
+  if (!validated) return;
+  const worker = { ...formValue.value };
+  worker.id = worker.id.trim();
+  worker.endpoint = worker.endpoint.trim();
+  worker.segLength = 1000;
+  worker.prevSegLength = 0;
+
+  if (props.worker === undefined) {
+    workspace.addWorker(worker);
+  } else {
+    const index = workspaceRef.value.workers.findIndex(
+      ({ id }) => id === props.worker?.id,
+    );
+    workspaceRef.value.workers[index] = worker;
+    emit('update:show', false);
+  }
+};
+
+const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
+</script>
+
+<template>
+  <c-modal
+    :show="show"
+    @update:show="$emit('update:show', $event)"
+    :title="verb + 'Murasaki翻译器'"
+  >
+    <n-form
+      ref="form"
+      :model="formValue"
+      :rules="formRules"
+      label-placement="left"
+      label-width="auto"
+    >
+      <n-form-item-row path="id" label="名字">
+        <n-input
+          v-model:value="formValue.id"
+          placeholder="给你的翻译器起个名字"
+          :input-props="{ spellcheck: false }"
+        />
+      </n-form-item-row>
+      <n-form-item-row path="endpoint" label="链接">
+        <n-input
+          v-model:value="formValue.endpoint"
+          placeholder="Murasaki 本地推理服务链接"
+          :input-props="{ spellcheck: false }"
+        />
+      </n-form-item-row>
+
+      <n-text depth="3" style="font-size: 12px">
+        # Murasaki 上传链路使用站点预设参数，默认分段 1000、前文 0
+        <br />
+        # 链接例子：http://127.0.0.1:8080
+      </n-text>
+    </n-form>
+
+    <template #action>
+      <c-button :label="verb" type="primary" @action="submit" />
+    </template>
+  </c-modal>
+</template>

--- a/web/src/repos/useTranslationCache.ts
+++ b/web/src/repos/useTranslationCache.ts
@@ -11,12 +11,19 @@ interface TranslationCacheDBSchema extends DBSchema {
     key: string;
     value: { hash: string; text: string[] };
   };
+  'murasaki-seg-cache': {
+    key: string;
+    value: { hash: string; text: string[] };
+  };
 }
 
-type TranslationCacheType = 'gpt-seg-cache' | 'sakura-seg-cache';
+type TranslationCacheType =
+  | 'gpt-seg-cache'
+  | 'sakura-seg-cache'
+  | 'murasaki-seg-cache';
 
 const createDb = lazy(() => {
-  return openDB<TranslationCacheDBSchema>('test', 3, {
+  return openDB<TranslationCacheDBSchema>('test', 4, {
     upgrade(db, _oldVersion, _newVersion, _transaction, _event) {
       try {
         db.createObjectStore('gpt-seg-cache', { keyPath: 'hash' });
@@ -25,6 +32,11 @@ const createDb = lazy(() => {
       }
       try {
         db.createObjectStore('sakura-seg-cache', { keyPath: 'hash' });
+      } catch (e) {
+        console.error(e);
+      }
+      try {
+        db.createObjectStore('murasaki-seg-cache', { keyPath: 'hash' });
       } catch (e) {
         console.error(e);
       }

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -197,6 +197,12 @@ const router = createRouter({
               component: () => import('./pages/workspace/SakuraWorkspace.vue'),
             },
             {
+              path: 'murasaki',
+              meta: { title: 'Murasaki工作区' },
+              component: () =>
+                import('./pages/workspace/MurasakiWorkspace.vue'),
+            },
+            {
               path: 'interactive',
               meta: { title: '交互翻译' },
               component: () => import('./pages/workspace/Interactive.vue'),
@@ -281,6 +287,7 @@ const router = createRouter({
         { path: '/novel-list', redirect: '/novel' }, // 2024-06-25
         { path: '/wenku-list', redirect: '/wenku' }, // 2024-06-25
         { path: '/sakura-workspace', redirect: '/workspace/sakura' },
+        { path: '/murasaki-workspace', redirect: '/workspace/murasaki' },
 
         // 404
         {

--- a/web/src/stores/key.ts
+++ b/web/src/stores/key.ts
@@ -11,4 +11,5 @@ export const LSKey = {
   SettingReader: 'setting-reader',
   WorkspaceGpt: 'workspace-gpt',
   WorkspaceSakura: 'workspace-sakura',
+  WorkspaceMurasaki: 'workspace-murasaki',
 } as const;

--- a/web/src/stores/local/GetTranslationFile.ts
+++ b/web/src/stores/local/GetTranslationFile.ts
@@ -14,7 +14,7 @@ export const getTranslationFile = async (
     id: string;
     mode: 'zh' | 'zh-jp' | 'jp-zh';
     translationsMode: 'parallel' | 'priority';
-    translations: ('sakura' | 'baidu' | 'youdao' | 'gpt')[];
+    translations: ('sakura' | 'baidu' | 'youdao' | 'gpt' | 'murasaki')[];
   },
 ) => {
   const filename = [

--- a/web/src/stores/useSettingStore.ts
+++ b/web/src/stores/useSettingStore.ts
@@ -2,6 +2,11 @@ import type { TranslatorId } from '@/model/Translator';
 import { defaultConverter, useLocalStorage, useOpenCC } from '@/util';
 import { LSKey } from './key';
 
+const ensureTranslatorLast = (
+  translators: TranslatorId[],
+  target: TranslatorId,
+): TranslatorId[] => [...translators.filter((item) => item !== target), target];
+
 export interface Setting {
   theme: 'light' | 'dark' | 'system';
   enabledTranslator: TranslatorId[];
@@ -37,9 +42,17 @@ export interface Setting {
 }
 
 export namespace Setting {
+  const defaultTranslationOrder: TranslatorId[] = [
+    'sakura',
+    'gpt',
+    'youdao',
+    'baidu',
+    'murasaki',
+  ];
+
   export const defaultValue: Setting = {
     theme: 'system',
-    enabledTranslator: ['baidu', 'youdao', 'gpt', 'sakura'],
+    enabledTranslator: ['baidu', 'youdao', 'gpt', 'sakura', 'murasaki'],
     tocSortReverse: false,
     //
     tocCollapseInNarrowScreen: true,
@@ -57,7 +70,7 @@ export namespace Setting {
     downloadFormat: {
       mode: 'zh-jp',
       translationsMode: 'priority',
-      translations: ['sakura', 'gpt', 'youdao', 'baidu'],
+      translations: [...defaultTranslationOrder],
       type: 'epub',
     },
     workspaceSound: false,
@@ -79,8 +92,33 @@ export namespace Setting {
       delete setting.isDark;
     }
     if (setting.enabledTranslator === undefined) {
-      setting.enabledTranslator = ['baidu', 'youdao', 'gpt', 'sakura'];
+      setting.enabledTranslator = [
+        'baidu',
+        'youdao',
+        'gpt',
+        'sakura',
+        'murasaki',
+      ];
     }
+    setting.enabledTranslator = ensureTranslatorLast(
+      setting.enabledTranslator,
+      'murasaki',
+    );
+    if (setting.downloadFormat === undefined) {
+      setting.downloadFormat = {
+        mode: 'zh-jp',
+        translationsMode: 'priority',
+        translations: [...defaultTranslationOrder],
+        type: 'epub',
+      };
+    }
+    if (setting.downloadFormat?.translations === undefined) {
+      setting.downloadFormat.translations = [...defaultTranslationOrder];
+    }
+    setting.downloadFormat.translations = ensureTranslatorLast(
+      setting.downloadFormat.translations,
+      'murasaki',
+    );
     if ((setting.downloadFormat.mode as string) === 'mix') {
       setting.downloadFormat.mode = 'zh-jp';
     } else if ((setting.downloadFormat.mode as string) === 'mix-reverse') {
@@ -158,10 +196,18 @@ export interface ReaderSetting {
 }
 
 export namespace ReaderSetting {
+  const defaultTranslationOrder: TranslatorId[] = [
+    'sakura',
+    'gpt',
+    'youdao',
+    'baidu',
+    'murasaki',
+  ];
+
   export const defaultValue: ReaderSetting = {
     mode: 'zh-jp',
     translationsMode: 'priority',
-    translations: ['sakura', 'gpt', 'youdao', 'baidu'],
+    translations: [...defaultTranslationOrder],
     clickArea: 'default',
     speakLanguages: ['jp'],
     pageTurnMode: 'page',
@@ -216,6 +262,13 @@ export namespace ReaderSetting {
       }
       delete setting.trimLeadingSpaces;
     }
+    if (setting.translations === undefined) {
+      setting.translations = [...defaultTranslationOrder];
+    }
+    setting.translations = ensureTranslatorLast(
+      setting.translations,
+      'murasaki',
+    );
   };
 
   export const modeOptions = [


### PR DESCRIPTION
## 变更概述
本 PR 以最小侵入方式将Murasaki模型集成到现有核心工作流（`web + server`），新增独立翻译链路，不影响既有 Sakura/GPT 等逻辑。

## 主要改动
1. Web 侧接入
- 新增 Murasaki 工作区、Worker UI、路由与交互入口。
- 接入任务队列、阅读器显示、下载与缓存流程。

2. 翻译核心链路
- 新增独立 `TranslatorMurasaki`。
- 增加严格上传校验：模型白名单 + Meta 严格匹配 + 固定参数约束。

3. 按行解析的工程化实现
- 实现“换行布局捕获与恢复”：
  - 输入前记录原始空行分布；
  - 翻译时仅传有效文本行（单 `\n`）；
  - 输出后按记录恢复空行结构，与目前项目要求的按行对齐要求一致。

4. Server 侧闭环
- 增加 `murasakiVersion` 上传与版本校验。
- 增加持久化/统计/检索相关字段，保证列表与导出一致。

## 优点
- 最小改动、低侵入、与现有结构一致。
- 针对模型训练格式为项目按行对齐的数据结构设计了更鲁棒的输入构造方案。
- 前后端校验和数据链路完整闭环。

## 影响
- 属于增量功能，兼容风险较低。
- 合并后建议补充论坛说明与回归测试（尤其是版本校验与多空行场景）。

## 其他说明
- murasaki模型是一个基于sakura-qwen3-base微调的带有思维链的ACGN特化翻译模型，针对轻小说翻译的已知困难问题进行了优化，有较好的上下文能力。
- 目前设定的允许上传的模型为Murasaki-14B-v0.2-Q6_K.gguf 与 Murasaki-14B-v0.2-IQ4_XS.gguf，可根据需要进行更改。

## 本地验证
- [x] 模型识别与 Meta 校验通过。
- [x] 翻译请求可正常返回。
- [x] 行布局恢复校验通过（含多空行等边界场景）。
