### PR TITLE
feat(web): 允许真正的停止文库上传

### DIFF
--- a/web/src/api/novel/client.ts
+++ b/web/src/api/novel/client.ts
@@ -21,33 +21,62 @@ export const setTokenGetter = (getter: () => string) => {
   tokenGetter = getter;
 };
 
-export const uploadFile = (
+export type UploadTask<T> = {
+  promise: Promise<T>;
+  abort: () => void;
+};
+export function uploadFile(
   url: string,
   name: string,
   file: File,
   onProgress: (p: number) => void,
-) => {
-  return new Promise<string>(function (resolve, reject) {
-    const formData = new FormData();
-    formData.append(name, file);
+): UploadTask<string> {
+  const formData = new FormData();
+  formData.append(name, file);
 
-    const xhr = new XMLHttpRequest();
+  const xhr = new XMLHttpRequest();
+  let settle = false;
+
+  const promise = new Promise<string>(function (resolve, reject) {
     xhr.open('POST', url);
     const token = tokenGetter();
     if (token) {
       xhr.setRequestHeader('Authorization', 'Bearer ' + token);
     }
+
     xhr.onload = () => {
+      if (settle) return;
+      settle = true;
       if (xhr.status === 200) {
         resolve(xhr.responseText);
       } else {
         reject(new Error(xhr.responseText));
       }
     };
+
+    xhr.onerror = () => {
+      if (settle) return;
+      settle = true;
+      reject(new Error('网络错误'));
+    };
+
+    xhr.onabort = () => {
+      if (settle) return;
+      settle = true;
+      reject(new Error('上传已取消'));
+    };
+
     xhr.upload.addEventListener('progress', (e) => {
       const percent = e.lengthComputable ? (e.loaded / e.total) * 100 : 0;
       onProgress(Math.ceil(percent));
     });
     xhr.send(formData);
   });
-};
+
+  const abort = () => {
+    if (settle) return;
+    xhr.abort();
+  };
+
+  return { promise, abort };
+}

--- a/web/src/pages/novel/components/UploadButton.vue
+++ b/web/src/pages/novel/components/UploadButton.vue
@@ -11,6 +11,7 @@ import { WenkuNovelRepo } from '@/repos';
 import { useNoticeStore, useWhoamiStore } from '@/stores';
 import { RegexUtil } from '@/util';
 import { getFullContent } from '@/util/file';
+import type { UploadTask } from '@/api/novel/client';
 
 const props = defineProps<{
   novelId: string;
@@ -70,6 +71,18 @@ async function beforeUpload({ file }: { file: UploadFileInfo }) {
   }
 }
 
+const uploadTasks: Record<string, UploadTask<string>> = {};
+
+async function cancelUpload(options: {
+  file: UploadFileInfo;
+  fileList: Array<UploadFileInfo>;
+  index: number;
+}): Promise<boolean> {
+  await uploadTasks[options.file.id]?.abort?.();
+  delete uploadTasks[options.file.id];
+  return true;
+}
+
 const customRequest = async ({
   file,
   onFinish,
@@ -81,20 +94,33 @@ const customRequest = async ({
     return;
   }
 
-  try {
-    const type = file.url === 'jp' ? 'jp' : 'zh';
-    await WenkuNovelRepo.createVolume(
-      props.novelId,
-      file.name,
-      type,
-      file.file as File,
-      (percent) => onProgress({ percent }),
-    );
-    onFinish();
-  } catch (e) {
-    onError();
-    message.error(`上传失败:${await formatError(e)}`);
-  }
+  const type = file.url === 'jp' ? 'jp' : 'zh';
+  const task: UploadTask<string> = WenkuNovelRepo.createVolume(
+    props.novelId,
+    file.name,
+    type,
+    file.file as File,
+    (percent) => onProgress({ percent }),
+  );
+  uploadTasks[file.id] = task;
+  task.promise
+    .then(() => {
+      delete uploadTasks[file.id];
+      onFinish();
+    })
+    .catch(async (e) => {
+      delete uploadTasks[file.id];
+      // 用户手动取消上传，不报错
+      if (e instanceof Error && e.message === '上传已取消') {
+        message.error(`上传已取消`);
+        return;
+      }
+      onError();
+      message.error(`上传失败:${await formatError(e)}`);
+    });
+  return {
+    abort: () => task.abort(),
+  };
 };
 
 const noticeStore = useNoticeStore();
@@ -126,6 +152,7 @@ const uploadVolumes = () => {
     :custom-request="customRequest"
     :show-trigger="haveReadRule"
     @before-upload="beforeUpload"
+    :on-remove="cancelUpload"
   >
     <c-button label="上传" :icon="PlusOutlined" />
   </n-upload>

--- a/web/src/repos/useWenkuNovel.ts
+++ b/web/src/repos/useWenkuNovel.ts
@@ -67,12 +67,32 @@ export const WenkuNovelRepo = {
       exact: true,
     }),
   ),
-  createVolume: withOnSuccess(WenkuNovelApi.createVolume, (_, novelId) =>
-    cache.invalidateQueries({
-      key: [ItemKey, novelId],
-      exact: true,
-    }),
-  ),
+  createVolume: (
+    novelId: string,
+    volumeId: string,
+    type: 'jp' | 'zh',
+    file: File,
+    onProgress: (p: number) => void,
+  ) => {
+    const task = WenkuNovelApi.createVolume(
+      novelId,
+      volumeId,
+      type,
+      file,
+      onProgress,
+    );
+
+    return <typeof task>{
+      abort: task.abort,
+      promise: task.promise.then(async (ret) => {
+        await cache.invalidateQueries({
+          key: [ItemKey, novelId],
+          exact: true,
+        });
+        return ret;
+      }),
+    };
+  },
   deleteVolume: withOnSuccess(WenkuNovelApi.deleteVolume, (_, novelId) =>
     cache.invalidateQueries({
       key: [ItemKey, novelId],


### PR DESCRIPTION
<img width="710" height="247" alt="image" src="https://github.com/user-attachments/assets/d18db1d1-273a-4f41-8a2c-2003ecfc58fc" />

是的，以前的 x 是假的。除非你刷新网页，否则还是在后台继续上传（只是 UI 不显示了而已）