### PR TITLE
feat(web): 网络小说阅读页 document.title 追加小说名称

### DIFF
--- a/web/src/pages/reader/Reader.vue
+++ b/web/src/pages/reader/Reader.vue
@@ -5,7 +5,7 @@ import { ReadHistoryApi } from '@/api';
 import { GenericNovelId } from '@/model/Common';
 import type { TranslatorId } from '@/model/Translator';
 import { checkIsMobile } from '@/pages/util';
-import { ReadPositionRepo } from '@/repos';
+import { ReadPositionRepo, WebNovelRepo } from '@/repos';
 import {
   useLocalVolumeStore,
   useReaderSettingStore,
@@ -48,6 +48,13 @@ const gnid = ((): GenericNovelId => {
 
 const store = useReaderStore(gnid);
 
+// 仅 web 小说需要获取小说元数据，用于在 document.title 中拼接小说名称
+const novelQuery =
+  gnid.type === 'web'
+    ? WebNovelRepo.useWebNovel(gnid.providerId, gnid.novelId)
+    : undefined;
+const novel = novelQuery?.data;
+
 const targetChapterId = ref('');
 const currentChapterId = ref('');
 const chapterResult = shallowRef<Result<ReaderChapter>>();
@@ -62,13 +69,22 @@ const novelUrl = (() => {
   }
 })();
 
+// 组合阅读页 document.title，显示「章节名称 | 小说名称」，小说元数据未就绪时仅显示章节名称
+const applyDocumentTitle = (chapter: ReaderChapter) => {
+  if (gnid.type === 'web' && novel?.value?.titleJp) {
+    document.title = `${chapter.titleJp} | ${novel.value.titleJp}`;
+  } else {
+    document.title = chapter.titleJp;
+  }
+};
+
 const updateChapter = (
   chapterId: string,
   result: Result<ReaderChapter>,
   replace = false,
 ) => {
   if (result.ok) {
-    document.title = result.value.titleJp;
+    applyDocumentTitle(result.value);
     if (gnid.type === 'web' && whoami.value.isSignedIn) {
       ReadHistoryApi.updateReadHistoryWeb(
         gnid.providerId,
@@ -99,6 +115,16 @@ const updateChapter = (
     router.push(`${prefix}/${chapterId}`);
   }
 };
+
+// 章节通常比小说元数据先到达，首次 updateChapter 时 novel 可能仍为 undefined，导致 title 暂时只有章节名
+// 元数据到达后由此 watch 重套一次，补上小说名称
+if (novel !== undefined) {
+  watch(novel, () => {
+    if (chapterResult.value?.ok) {
+      applyDocumentTitle(chapterResult.value.value);
+    }
+  });
+}
 
 const navToChapter = async (chapterId: string) => {
   targetChapterId.value = chapterId;


### PR DESCRIPTION
## 概述

网络小说阅读页浏览器分页标题原本只显示章节名称，切换到其他标签页或查看书签时难以辨识所属小说。

本 PR 将 `document.title` 调整为：`章节名称 | 小说名称`

## 实现

- 在 `Reader.vue` setup 阶段，当 `gnid.type === 'web'` 时调用既有的 `WebNovelRepo.useWebNovel(providerId, novelId)` 获取小说元数据
- 抽出 `applyDocumentTitle(chapter)` helper 统一设置 `document.title`，替代原本散落的 `document.title = result.value.titleJp`
- 新增 `watch(novel, ...)`：处理「章节先到、小说元数据后到」的情形，元数据到达后回补小说名称

## 行为说明

  | 情境 | document.title |
  | --- | --- |
  | web 小说，元数据已就绪 | `章节名称 \| 小说名称` |
  | web 小说，元数据加载中 | `章节名称` (fallback，待元数据到达自动回补) |
  | 其他页面 | 不受影响 (仍由 `router.ts` 的 `afterEach` 处理) |