### PR TITLE
fix(wenku): 收藏按更新时间排序使用小说实时 updateAt

### DIFF
--- a/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
@@ -68,12 +68,19 @@ class WenkuNovelFavoredRepository(
 
         val sortBson = when (sort) {
             FavoredNovelListSort.CreateAt -> descending(WenkuNovelFavoriteDbModel::createAt.field())
-            FavoredNovelListSort.UpdateAt -> descending(WenkuNovelFavoriteDbModel::updateAt.field())
+            FavoredNovelListSort.UpdateAt -> descending("novel.${WenkuNovel::updateAt.field()}")
         }
 
         val doc = userFavoredWenkuCollection
             .aggregate<PageModel>(
                 match(filterBson),
+                lookup(
+                    from = MongoCollectionNames.WENKU_NOVEL,
+                    localField = WenkuNovelFavoriteDbModel::novelId.field(),
+                    foreignField = WenkuNovel::id.field(),
+                    as = "novel"
+                ),
+                unwind("\$novel"),
                 sort(sortBson),
                 facet(
                     Facet("count", count()),
@@ -81,13 +88,6 @@ class WenkuNovelFavoredRepository(
                         "items",
                         skip(page * pageSize),
                         limit(pageSize),
-                        lookup(
-                            /* from = */ MongoCollectionNames.WENKU_NOVEL,
-                            /* localField = */ WenkuNovelFavoriteDbModel::novelId.field(),
-                            /* foreignField = */ WenkuNovel::id.field(),
-                            /* as = */ "novel"
-                        ),
-                        unwind("\$novel"),
                         replaceRoot("\$novel"),
                     )
                 ),


### PR DESCRIPTION
## 问题
fixes #329

文库收藏页 `/favorite/wenku/default` 按更新时间排序不生效。排序用的 `updateAt` 是收藏那一刻的快照，之后新卷/翻译提交不会再刷新，导致排序始终停留在收藏时的状态。

## 修复
`WenkuNovelFavoredRepository.listFavoriteWenkuNovel()` 的 MongoDB 聚合管道重排：

- **之前**: match → sort(收藏记录.updateAt) → facet(count, skip → limit → lookup → unwind → replaceRoot)
- **之后**: match → lookup → unwind → sort(novel.updateAt desc) → facet(count, skip → limit → replaceRoot)

`$lookup` + `$unwind` 提到 `$sort` 之前，排序直接使用 join 过来的小说文档的实时 `updateAt`。
