### PR TITLE
fix(wenku): 收藏列表按更新时间排序使用小说实时 updateAt 而非快照

### DIFF
--- a/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
@@ -68,26 +68,26 @@ class WenkuNovelFavoredRepository(
 
         val sortBson = when (sort) {
             FavoredNovelListSort.CreateAt -> descending(WenkuNovelFavoriteDbModel::createAt.field())
-            FavoredNovelListSort.UpdateAt -> descending(WenkuNovelFavoriteDbModel::updateAt.field())
+            FavoredNovelListSort.UpdateAt -> descending("novel.${WenkuNovel::updateAt.field()}")
         }
 
         val doc = userFavoredWenkuCollection
             .aggregate<PageModel>(
                 match(filterBson),
-                sort(sortBson),
+                lookup(
+                    from = MongoCollectionNames.WENKU_NOVEL,
+                    localField = WenkuNovelFavoriteDbModel::novelId.field(),
+                    foreignField = WenkuNovel::id.field(),
+                    as = "novel"
+                ),
+                unwind("\$novel"),
                 facet(
                     Facet("count", count()),
                     Facet(
                         "items",
+                        sort(sortBson),
                         skip(page * pageSize),
                         limit(pageSize),
-                        lookup(
-                            /* from = */ MongoCollectionNames.WENKU_NOVEL,
-                            /* localField = */ WenkuNovelFavoriteDbModel::novelId.field(),
-                            /* foreignField = */ WenkuNovel::id.field(),
-                            /* as = */ "novel"
-                        ),
-                        unwind("\$novel"),
                         replaceRoot("\$novel"),
                     )
                 ),

--- a/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/wenku/repository/WenkuNovelFavoredRepository.kt
@@ -75,10 +75,10 @@ class WenkuNovelFavoredRepository(
             .aggregate<PageModel>(
                 match(filterBson),
                 lookup(
-                    from = MongoCollectionNames.WENKU_NOVEL,
-                    localField = WenkuNovelFavoriteDbModel::novelId.field(),
-                    foreignField = WenkuNovel::id.field(),
-                    as = "novel"
+                    /* from = */ MongoCollectionNames.WENKU_NOVEL,
+                    /* localField = */ WenkuNovelFavoriteDbModel::novelId.field(),
+                    /* foreignField = */ WenkuNovel::id.field(),
+                    /* as = */ "novel"
                 ),
                 unwind("\$novel"),
                 facet(


### PR DESCRIPTION
## 修复

修复文库收藏页 `/favorite/wenku/default` 按"更新时间"排序不生效的问题。

### 根因
MongoDB 聚合管道中 `$facet` 不保持输入文档顺序，因此 `$sort` 必须在 `$facet` 内部的 items 子管道中执行，且排序字段应使用 `$lookup` join 后的 `novel.updateAt` 而非收藏记录里的快照。

### 改动
将 `$lookup` + `$unwind` 前置到 `$facet` 之前，并将 `$sort` 移入 `$facet` 内，使用 `novel.updateAt` 排序。

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)