### PR TITLE
feat(glossary): 术语表分组管理、编辑历史记录与交互优化

### DIFF
--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -46,6 +46,8 @@ declare module 'vue' {
     EmailButton: typeof import('./components/EmailButton.vue')['default']
     FavoriteButton: typeof import('./pages/novel/components/FavoriteButton.vue')['default']
     GlossaryButton: typeof import('./components/GlossaryButton.vue')['default']
+    GlossaryGroupTabs: typeof import('./components/GlossaryGroupTabs.vue')['default']
+    GlossaryTermTable: typeof import('./components/GlossaryTermTable.vue')['default']
     GptWorkerModal: typeof import('./pages/workspace/components/GptWorkerModal.vue')['default']
     ImageCard: typeof import('./components/ImageCard.vue')['default']
     JobQueue: typeof import('./pages/workspace/components/JobQueue.vue')['default']

--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -46,6 +46,7 @@ declare module 'vue' {
     EmailButton: typeof import('./components/EmailButton.vue')['default']
     FavoriteButton: typeof import('./pages/novel/components/FavoriteButton.vue')['default']
     GlossaryButton: typeof import('./components/GlossaryButton.vue')['default']
+    GlossaryColumn: typeof import('./components/GlossaryColumn.vue')['default']
     GlossaryGroupTabs: typeof import('./components/GlossaryGroupTabs.vue')['default']
     GlossaryTermTable: typeof import('./components/GlossaryTermTable.vue')['default']
     GptWorkerModal: typeof import('./pages/workspace/components/GptWorkerModal.vue')['default']

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -411,16 +411,6 @@ const revertTerm = (jp: string) => {
     const found = entries.find((e) => e.jp === jp);
     if (found) {
       glossary.value[jp] = found.zh;
-      if (selectedGroup.value && selectedGroup.value !== '未分组') {
-        GlossaryGroup.moveTerm(
-          novelId.value,
-          jp,
-          found.zh,
-          selectedGroup.value,
-        );
-      } else {
-        GlossaryGroup.removeTerm(novelId.value, jp);
-      }
       loadGroups();
       return;
     }

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -12,7 +12,9 @@ import {
 import { copyToClipBoard, doAction } from '@/pages/util';
 import { useLocalVolumeStore, useWhoamiStore } from '@/stores';
 import { downloadFile } from '@/util';
+import { useWindowSize } from '@vueuse/core';
 import GlossaryTermTable from './GlossaryTermTable.vue';
+import GlossaryGroupTabs from './GlossaryGroupTabs.vue';
 
 const props = defineProps<{
   gnid?: GenericNovelId;
@@ -33,6 +35,9 @@ const novelId = computed(() => {
   if (!gnid) return '';
   return GenericNovelId.toString(gnid);
 });
+
+const { width } = useWindowSize();
+const isNarrow = computed(() => width.value < 600);
 
 const toggleGlossaryModal = () => {
   if (showGlossaryModal.value === false) {
@@ -533,14 +538,21 @@ const submitGlossary = () =>
       </n-flex>
     </template>
 
-    <!-- 主内容区：左侧分组 + 右侧术语 -->
+    <!-- 主内容区：左侧分组 + 右侧术语（桌面端） / 上标签栏 + 下内容（移动端） -->
     <div
       v-if="novelId"
-      style="display: flex; gap: 16px; min-height: 300px"
+      :style="{
+        display: 'flex',
+        flexDirection: isNarrow ? 'column' : 'row',
+        gap: '12px',
+        minHeight: '300px',
+      }"
       @keydown="onKeydown"
     >
-      <!-- 左侧分组侧边栏 -->
+      <!-- ======== 分组选择器 ======== -->
+      <!-- 桌面端：纵向侧边栏 -->
       <div
+        v-if="!isNarrow"
         style="
           width: 150px;
           flex-shrink: 0;
@@ -550,99 +562,70 @@ const submitGlossary = () =>
       >
         <n-flex vertical size="small">
           <n-text strong style="font-size: 13px">分组</n-text>
-
-          <div
-            v-for="name in groupNames"
-            :key="name"
-            @click="
-              selectedGroup = name;
-              clearSelection();
+          <GlossaryGroupTabs
+            :group-names="groupNames"
+            :display-data="displayData"
+            :selected-group="selectedGroup"
+            :editing-group-name="editingGroupName"
+            :editing-group-new-name="editingGroupNewName"
+            :show-new-group-input="showNewGroupInput"
+            :new-group-name="newGroupName"
+            :ungrouped-count="ungroupedEntries.length"
+            @select="
+              (name) => {
+                selectedGroup = name;
+                clearSelection();
+              }
             "
-            :style="{
-              padding: '4px 8px',
-              cursor: 'pointer',
-              borderRadius: '4px',
-              fontSize: '12px',
-              background:
-                selectedGroup === name
-                  ? 'var(--primary-color-hover, #eee)'
-                  : 'transparent',
-            }"
-          >
-            <template v-if="editingGroupName === name">
-              <n-input
-                v-model:value="editingGroupNewName"
-                size="tiny"
-                @blur="finishRename"
-                @keydown.enter="finishRename"
-              />
-            </template>
-            <template v-else>
-              <n-flex justify="space-between" align="center">
-                <n-text @dblclick="startRename(name)" style="flex: 1">
-                  {{ name }}
-                </n-text>
-                <n-text depth="3" style="font-size: 10px">
-                  {{ displayData[name]?.length ?? 0 }}
-                </n-text>
-              </n-flex>
-            </template>
-          </div>
-
-          <div
-            @click="
-              selectedGroup = undefined;
-              clearSelection();
-            "
-            :style="{
-              padding: '4px 8px',
-              cursor: 'pointer',
-              borderRadius: '4px',
-              fontSize: '12px',
-              background:
-                selectedGroup === undefined
-                  ? 'var(--primary-color-hover, #eee)'
-                  : 'transparent',
-            }"
-          >
-            <n-flex justify="space-between" align="center">
-              <n-text>未分组</n-text>
-              <n-text depth="3" style="font-size: 10px">
-                {{ ungroupedEntries.length }}
-              </n-text>
-            </n-flex>
-          </div>
-
-          <div v-if="showNewGroupInput" style="margin-top: 4px">
-            <n-input
-              v-model:value="newGroupName"
-              size="tiny"
-              placeholder="新分组名"
-              @keydown.enter="addNewGroup"
-              @blur="addNewGroup"
-            />
-          </div>
-          <c-button
-            v-else
-            :icon="AddOutlined"
-            label="新建组"
-            size="tiny"
-            text
-            @action="showNewGroupInput = true"
-          />
-
-          <c-button
-            v-if="selectedGroup && selectedGroup !== '未分组'"
-            label="删除此组"
-            size="tiny"
-            text
-            type="error"
-            @action="deleteCurrentGroup"
+            @start-rename="startRename"
+            @finish-rename="finishRename"
+            @update:editing-group-new-name="editingGroupNewName = $event"
+            @add-new-group="addNewGroup"
+            @update:new-group-name="newGroupName = $event"
+            @show-new-group="showNewGroupInput = true"
+            @delete-group="deleteCurrentGroup"
           />
         </n-flex>
       </div>
 
-      <!-- 右侧术语列表 -->
+      <!-- 移动端：横向滚动标签栏 -->
+      <div
+        v-else
+        style="
+          overflow-x: auto;
+          white-space: nowrap;
+          padding-bottom: 4px;
+          border-bottom: 1px solid #eee;
+        "
+      >
+        <n-flex align="center" style="flex-wrap: nowrap; gap: 4px">
+          <GlossaryGroupTabs
+            :group-names="groupNames"
+            :display-data="displayData"
+            :selected-group="selectedGroup"
+            :editing-group-name="editingGroupName"
+            :editing-group-new-name="editingGroupNewName"
+            :show-new-group-input="showNewGroupInput"
+            :new-group-name="newGroupName"
+            :ungrouped-count="ungroupedEntries.length"
+            @select="
+              (name) => {
+                selectedGroup = name;
+                clearSelection();
+              }
+            "
+            @start-rename="startRename"
+            @finish-rename="finishRename"
+            @update:editing-group-new-name="editingGroupNewName = $event"
+            @add-new-group="addNewGroup"
+            @update:new-group-name="newGroupName = $event"
+            @show-new-group="showNewGroupInput = true"
+            @delete-group="deleteCurrentGroup"
+          />
+        </n-flex>
+      </div>
+
+      <!-- ======== 术语列表 ======== -->
       <div style="flex: 1; min-width: 0">
         <template v-if="selectedGroup && currentGroupEntries.length > 0">
           <n-text
@@ -675,7 +658,7 @@ const submitGlossary = () =>
             depth="3"
             style="font-size: 11px; margin-bottom: 8px; display: block"
           >
-            未分组术语 — 点击左侧分组名将术语移入分组
+            未分组术语 — 点击分组名将术语移入分组
           </n-text>
           <GlossaryTermTable
             :entries="ungroupedEntries"

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -10,7 +10,7 @@ import {
   type GlossaryEntry,
 } from '@/model/GlossaryGroup';
 import { copyToClipBoard, doAction } from '@/pages/util';
-import { useLocalVolumeStore, useWhoamiStore } from '@/stores';
+import { useLocalVolumeStore, useSettingStore, useWhoamiStore } from '@/stores';
 import { downloadFile } from '@/util';
 import { useWindowSize } from '@vueuse/core';
 import GlossaryTermTable from './GlossaryTermTable.vue';
@@ -25,6 +25,9 @@ const message = useMessage();
 
 const whoamiStore = useWhoamiStore();
 const { whoami } = storeToRefs(whoamiStore);
+
+const settingStore = useSettingStore();
+const { setting } = storeToRefs(settingStore);
 
 const glossary = ref<Glossary>({});
 
@@ -613,7 +616,7 @@ const submitGlossary = () =>
     <div v-if="novelId" tabindex="0" style="outline: none" @keydown="onKeydown">
       <!-- ======== 桌面端：标签页 + 表格 ======== -->
       <div
-        v-if="!isNarrow"
+        v-if="!isNarrow && setting.useGlossaryGroups"
         :style="{
           display: 'flex',
           flexDirection: 'column',
@@ -714,7 +717,7 @@ const submitGlossary = () =>
         </div>
       </div>
 
-      <!-- ======== 移动端：简易表格（不启用分组） ======== -->
+      <!-- ======== 简易表格（移动端 或 关闭分组模式） ======== -->
       <div v-else>
         <n-table
           v-if="Object.keys(glossary).length !== 0"

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -255,6 +255,34 @@ function onReorderGroups(from: string, to: string) {
   GlossaryGroup.saveGroups(novelId.value, groups.value, order);
 }
 
+function handleSortByTime() {
+  if (!novelId.value) return;
+  const name = selectedGroup.value ?? '未分组';
+  GlossaryGroup.sortGroupByTime(novelId.value, name, glossary.value, false);
+  loadGroups();
+}
+
+function handleSortByTimeReverse() {
+  if (!novelId.value) return;
+  const name = selectedGroup.value ?? '未分组';
+  GlossaryGroup.sortGroupByTime(novelId.value, name, glossary.value, true);
+  loadGroups();
+}
+
+function handleSortByKana() {
+  if (!novelId.value) return;
+  const name = selectedGroup.value ?? '未分组';
+  GlossaryGroup.sortGroupByKana(novelId.value, name, false);
+  loadGroups();
+}
+
+function handleSortByKanaReverse() {
+  if (!novelId.value) return;
+  const name = selectedGroup.value ?? '未分组';
+  GlossaryGroup.sortGroupByKana(novelId.value, name, true);
+  loadGroups();
+}
+
 // ========== 多选相关 ==========
 const selectedTerms = ref<Set<string>>(new Set());
 const lastClickedJp = ref<string | null>(null);
@@ -622,6 +650,10 @@ const submitGlossary = () =>
             @drop-term="onDropTerm"
             @delete-group-request="onDeleteGroupRequest"
             @reorder-groups="onReorderGroups"
+            @sort-by-time="handleSortByTime"
+            @sort-by-time-reverse="handleSortByTimeReverse"
+            @sort-by-kana="handleSortByKana"
+            @sort-by-kana-reverse="handleSortByKanaReverse"
           />
         </div>
 

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -410,7 +410,7 @@ const revertTerm = (jp: string) => {
   for (const [, entries] of Object.entries(g)) {
     const found = entries.find((e) => e.jp === jp);
     if (found) {
-      glossary.value[jp] = found.zh;
+      glossary.value = { ...glossary.value, [jp]: found.zh };
       loadGroups();
       return;
     }

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -231,11 +231,9 @@ function onReorderGroups(from: string, to: string) {
   const g = GlossaryGroup.getGroups(novelId.value);
   const names = Object.keys(g);
   const fromIdx = names.indexOf(from);
-  let toIdx = names.indexOf(to);
+  const toIdx = names.indexOf(to);
   if (fromIdx === -1 || toIdx === -1) return;
-  const [moved] = names.splice(fromIdx, 1);
-  if (fromIdx < toIdx) toIdx--;
-  names.splice(toIdx + 1, 0, moved);
+  [names[fromIdx], names[toIdx]] = [names[toIdx], names[fromIdx]];
   const newGroups: GlossaryGroupMap = {};
   for (const name of names) {
     newGroups[name] = g[name] ?? [];

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -51,6 +51,7 @@ const toggleGlossaryModal = () => {
 
 // ========== 分组相关 ==========
 const groups = ref<GlossaryGroupMap>({});
+const groupOrder = ref<string[]>([]);
 const selectedGroup = ref<string | undefined>(undefined);
 const newGroupName = ref('');
 const showNewGroupInput = ref(false);
@@ -60,11 +61,12 @@ const editingGroupNewName = ref('');
 function loadGroups() {
   if (!novelId.value) return;
   groups.value = GlossaryGroup.getGroups(novelId.value);
+  groupOrder.value = GlossaryGroup.getGroupOrder(novelId.value);
 }
 
 function saveGroups() {
   if (!novelId.value) return;
-  GlossaryGroup.saveGroups(novelId.value, groups.value);
+  GlossaryGroup.saveGroups(novelId.value, groups.value, groupOrder.value);
 }
 
 // 监听跨标签页变更
@@ -75,7 +77,8 @@ if (typeof window !== 'undefined') {
       e.newValue !== null
     ) {
       try {
-        groups.value = JSON.parse(e.newValue);
+        groups.value = GlossaryGroup.getGroups(novelId.value);
+        groupOrder.value = GlossaryGroup.getGroupOrder(novelId.value);
       } catch {
         /* ignore */
       }
@@ -92,11 +95,15 @@ const displayData = computed<GlossaryGroupMap>(() => {
     }));
     return result;
   }
-  return GlossaryGroup.buildDisplayData(groups.value, glossary.value);
+  return GlossaryGroup.buildDisplayData(
+    groups.value,
+    glossary.value,
+    groupOrder.value,
+  );
 });
 
 const groupNames = computed(() => {
-  return Object.keys(displayData.value).filter((n) => n !== '未分组');
+  return groupOrder.value.filter((n) => n in displayData.value);
 });
 
 const currentGroupEntries = computed<GlossaryEntry[]>(() => {
@@ -228,18 +235,13 @@ function confirmDeleteGroup() {
 
 function onReorderGroups(from: string, to: string) {
   if (!novelId.value) return;
-  const g = GlossaryGroup.getGroups(novelId.value);
-  const names = Object.keys(g);
-  const fromIdx = names.indexOf(from);
-  const toIdx = names.indexOf(to);
+  const order = [...groupOrder.value];
+  const fromIdx = order.indexOf(from);
+  const toIdx = order.indexOf(to);
   if (fromIdx === -1 || toIdx === -1) return;
-  [names[fromIdx], names[toIdx]] = [names[toIdx], names[fromIdx]];
-  const newGroups: GlossaryGroupMap = {};
-  for (const name of names) {
-    newGroups[name] = g[name] ?? [];
-  }
-  GlossaryGroup.saveGroups(novelId.value, newGroups);
-  loadGroups();
+  [order[fromIdx], order[toIdx]] = [order[toIdx], order[fromIdx]];
+  groupOrder.value = order;
+  GlossaryGroup.saveGroups(novelId.value, groups.value, order);
 }
 
 // ========== 多选相关 ==========

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -192,9 +192,12 @@ function removeTermFromCurrentGroup(jp: string) {
   loadGroups();
 }
 
-function onDropTerm(jp: string | string[], groupName: string | undefined) {
+function onDropTerm(jp: string, groupName: string | undefined) {
   if (!novelId.value) return;
-  const jps = Array.isArray(jp) ? jp : [jp];
+  const jps =
+    selectedTerms.value.has(jp) && selectedTerms.value.size > 1
+      ? [...selectedTerms.value]
+      : [jp];
   for (const j of jps) {
     if (!groupName || groupName === '未分组') {
       const zh = glossary.value[j] ?? getLocalZh(j) ?? '';

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -192,15 +192,18 @@ function removeTermFromCurrentGroup(jp: string) {
   loadGroups();
 }
 
-function onDropTerm(jp: string, groupName: string | undefined) {
+function onDropTerm(jp: string | string[], groupName: string | undefined) {
   if (!novelId.value) return;
-  if (!groupName || groupName === '未分组') {
-    const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
-    GlossaryGroup.removeTerm(novelId.value, jp);
-    GlossaryGroup.addToUngrouped(novelId.value, jp, zh);
-  } else {
-    const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
-    GlossaryGroup.moveTerm(novelId.value, jp, zh, groupName);
+  const jps = Array.isArray(jp) ? jp : [jp];
+  for (const j of jps) {
+    if (!groupName || groupName === '未分组') {
+      const zh = glossary.value[j] ?? getLocalZh(j) ?? '';
+      GlossaryGroup.removeTerm(novelId.value, j);
+      GlossaryGroup.addToUngrouped(novelId.value, j, zh);
+    } else {
+      const zh = glossary.value[j] ?? getLocalZh(j) ?? '';
+      GlossaryGroup.moveTerm(novelId.value, j, zh, groupName);
+    }
   }
   loadGroups();
 }
@@ -306,8 +309,13 @@ function toggleSelect(jp: string, event: MouseEvent) {
       selectedTerms.value = next;
     }
   } else {
-    selectedTerms.value = new Set([jp]);
-    lastClickedJp.value = jp;
+    if (selectedTerms.value.size === 1 && selectedTerms.value.has(jp)) {
+      selectedTerms.value = new Set();
+      lastClickedJp.value = null;
+    } else {
+      selectedTerms.value = new Set([jp]);
+      lastClickedJp.value = jp;
+    }
   }
 }
 

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -42,6 +42,7 @@ const isNarrow = computed(() => width.value < 600);
 const toggleGlossaryModal = () => {
   if (showGlossaryModal.value === false) {
     glossary.value = { ...props.value };
+    GlossaryGroup.syncUngrouped(novelId.value, glossary.value);
     loadGroups();
     selectedGroup.value = undefined;
     selectedTerms.value = new Set();
@@ -185,14 +186,18 @@ function deleteCurrentGroup(groupName?: string) {
 
 function removeTermFromCurrentGroup(jp: string) {
   if (!novelId.value) return;
+  const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
   GlossaryGroup.removeTerm(novelId.value, jp);
+  GlossaryGroup.addToUngrouped(novelId.value, jp, zh);
   loadGroups();
 }
 
 function onDropTerm(jp: string, groupName: string | undefined) {
   if (!novelId.value) return;
   if (!groupName || groupName === '未分组') {
+    const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
     GlossaryGroup.removeTerm(novelId.value, jp);
+    GlossaryGroup.addToUngrouped(novelId.value, jp, zh);
   } else {
     const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
     GlossaryGroup.moveTerm(novelId.value, jp, zh, groupName);
@@ -237,9 +242,15 @@ function onReorderGroups(from: string, to: string) {
   if (!novelId.value) return;
   const order = [...groupOrder.value];
   const fromIdx = order.indexOf(from);
-  const toIdx = order.indexOf(to);
-  if (fromIdx === -1 || toIdx === -1) return;
-  [order[fromIdx], order[toIdx]] = [order[toIdx], order[fromIdx]];
+  if (fromIdx === -1) return;
+  order.splice(fromIdx, 1);
+  if (to) {
+    const toIdx = order.indexOf(to);
+    if (toIdx === -1) return;
+    order.splice(toIdx, 0, from);
+  } else {
+    order.push(from);
+  }
   groupOrder.value = order;
   GlossaryGroup.saveGroups(novelId.value, groups.value, order);
 }
@@ -625,12 +636,19 @@ const submitGlossary = () =>
               :get-local-zh="getLocalZh"
               :novel-id="novelId"
               :in-group="true"
+              :group-name="selectedGroup"
               @toggle-select="toggleSelect"
               @delete-term="deleteTerm"
               @remove-from-group="removeTermFromCurrentGroup"
               @revert-term="revertTerm"
               @revert-to-local-zh="revertToLocalZh"
               @clear-local-record="clearLocalRecord"
+              @reorder-term="
+                (from, to) => {
+                  GlossaryGroup.reorderTerm(novelId, selectedGroup!, from, to);
+                  loadGroups();
+                }
+              "
             />
           </template>
 
@@ -650,6 +668,12 @@ const submitGlossary = () =>
               @revert-term="revertTerm"
               @revert-to-local-zh="revertToLocalZh"
               @clear-local-record="clearLocalRecord"
+              @reorder-term="
+                (from, to) => {
+                  GlossaryGroup.reorderTerm(novelId, '未分组', from, to);
+                  loadGroups();
+                }
+              "
             />
           </template>
 

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -544,36 +544,13 @@ const submitGlossary = () =>
             size="small"
             @action="downloadGlossaryAsJsonFile"
           />
-
-          <!-- 单向同步按钮 -->
-          <template v-if="!isNarrow">
-            <n-divider vertical />
-            <c-button
-              label="远程→本地"
-              :round="false"
-              size="small"
-              @action="syncRemoteToLocal"
-            />
-            <c-button
-              label="本地→编辑区"
-              :round="false"
-              size="small"
-              @action="syncLocalToEditing"
-            />
-          </template>
-
-          <c-button
-            v-if="whoami.isAdmin"
-            secondary
-            type="error"
-            label="清空"
-            :round="false"
-            size="small"
-            @action="showClearConfirm = true"
-          />
-        </n-flex>
-
-        <n-flex align="center" :wrap="false">
+          <n-text
+            v-if="lastDeletedTerm !== undefined"
+            depth="3"
+            style="font-size: 12px"
+          >
+            {{ lastDeletedTerm }}
+          </n-text>
           <c-button
             :disabled="deletedTerms.length === 0"
             label="撤销删除"
@@ -582,16 +559,9 @@ const submitGlossary = () =>
             @action="undoDeleteTerm"
           />
           <n-text
-            v-if="lastDeletedTerm !== undefined"
-            depth="3"
-            style="font-size: 12px"
-          >
-            {{ lastDeletedTerm }}
-          </n-text>
-          <n-text
             v-if="selectedTerms.size > 0"
             depth="3"
-            style="font-size: 12px; margin-left: 8px"
+            style="font-size: 12px"
           >
             已选 {{ selectedTerms.size }} 项 — Delete 键批量删除
           </n-text>
@@ -600,7 +570,7 @@ const submitGlossary = () =>
     </template>
 
     <!-- 主内容区 -->
-    <div v-if="novelId" @keydown="onKeydown">
+    <div v-if="novelId" tabindex="0" style="outline: none" @keydown="onKeydown">
       <!-- ======== 桌面端：标签页 + 表格 ======== -->
       <div
         v-if="!isNarrow"
@@ -621,6 +591,10 @@ const submitGlossary = () =>
             :show-new-group-input="showNewGroupInput"
             :new-group-name="newGroupName"
             :ungrouped-count="ungroupedEntries.length"
+            :is-admin="whoami.isAdmin"
+            @sync-remote-to-local="syncRemoteToLocal"
+            @sync-local-to-editing="syncLocalToEditing"
+            @clear-request="showClearConfirm = true"
             @select="
               (name) => {
                 selectedGroup = name;

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { DeleteOutlineOutlined, AddOutlined } from '@vicons/material';
+import { DeleteOutlineOutlined } from '@vicons/material';
 
 import { WebNovelApi, WenkuNovelApi } from '@/api';
 import { GenericNovelId } from '@/model/Common';
@@ -168,25 +168,79 @@ function finishRename() {
   editingGroupNewName.value = '';
 }
 
-function deleteCurrentGroup() {
-  const name = selectedGroup.value;
+function deleteCurrentGroup(groupName?: string) {
+  const name = groupName ?? selectedGroup.value;
   if (!name) return;
   GlossaryGroup.deleteGroup(novelId.value, name);
   loadGroups();
-  selectedGroup.value = undefined;
-}
-
-function moveTermToGroup(jp: string) {
-  const name = selectedGroup.value;
-  if (!name || name === '未分组' || !novelId.value) return;
-  const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
-  GlossaryGroup.moveTerm(novelId.value, jp, zh, name);
-  loadGroups();
+  if (selectedGroup.value === name) selectedGroup.value = undefined;
 }
 
 function removeTermFromCurrentGroup(jp: string) {
   if (!novelId.value) return;
   GlossaryGroup.removeTerm(novelId.value, jp);
+  loadGroups();
+}
+
+function onDropTerm(jp: string, groupName: string | undefined) {
+  if (!novelId.value) return;
+  if (!groupName || groupName === '未分组') {
+    GlossaryGroup.removeTerm(novelId.value, jp);
+  } else {
+    const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
+    GlossaryGroup.moveTerm(novelId.value, jp, zh, groupName);
+  }
+  loadGroups();
+}
+
+function onDeleteGroupRequest(name: string) {
+  const entries = displayData.value[name];
+  if (!entries || entries.length === 0) {
+    GlossaryGroup.deleteGroup(novelId.value, name);
+    loadGroups();
+    if (selectedGroup.value === name) selectedGroup.value = undefined;
+  } else {
+    deleteGroupConfirmName.value = name;
+  }
+}
+
+const deleteGroupConfirmName = ref<string | null>(null);
+const showDeleteGroupConfirm = computed({
+  get: () => deleteGroupConfirmName.value !== null,
+  set: (v: boolean) => {
+    if (!v) deleteGroupConfirmName.value = null;
+  },
+});
+const deleteGroupConfirmCount = computed(() => {
+  const name = deleteGroupConfirmName.value;
+  if (!name) return 0;
+  return displayData.value[name]?.length ?? 0;
+});
+
+function confirmDeleteGroup() {
+  const name = deleteGroupConfirmName.value;
+  if (!name || !novelId.value) return;
+  GlossaryGroup.deleteGroup(novelId.value, name);
+  deleteGroupConfirmName.value = null;
+  loadGroups();
+  if (selectedGroup.value === name) selectedGroup.value = undefined;
+}
+
+function onReorderGroups(from: string, to: string) {
+  if (!novelId.value) return;
+  const g = GlossaryGroup.getGroups(novelId.value);
+  const names = Object.keys(g);
+  const fromIdx = names.indexOf(from);
+  let toIdx = names.indexOf(to);
+  if (fromIdx === -1 || toIdx === -1) return;
+  const [moved] = names.splice(fromIdx, 1);
+  if (fromIdx < toIdx) toIdx--;
+  names.splice(toIdx + 1, 0, moved);
+  const newGroups: GlossaryGroupMap = {};
+  for (const name of names) {
+    newGroups[name] = g[name] ?? [];
+  }
+  GlossaryGroup.saveGroups(novelId.value, newGroups);
   loadGroups();
 }
 
@@ -257,6 +311,7 @@ function onKeydown(e: KeyboardEvent) {
 /** 远程 → 本地：用服务端术语表覆盖当前编辑 */
 function syncRemoteToLocal() {
   glossary.value = { ...props.value };
+  loadGroups();
   message.success('已从远程同步到本地编辑');
 }
 
@@ -299,12 +354,14 @@ const undoDeleteTerm = () => {
   if (deletedTerms.value.length === 0) return;
   const [jp, zh] = deletedTerms.value.pop()!;
   glossary.value[jp] = zh;
+  loadGroups();
 };
 
 const deleteTerm = (jp: string) => {
   if (jp in glossary.value) {
     deletedTerms.value.push([jp, glossary.value[jp]]);
     delete glossary.value[jp];
+    loadGroups();
   }
 };
 
@@ -347,6 +404,7 @@ const addTerm = () => {
   if (jp && zh) {
     glossary.value[jp.trim()] = zh.trim();
     termsToAdd.value = ['', ''];
+    loadGroups();
   }
 };
 
@@ -367,6 +425,7 @@ const importGlossary = () => {
     message.success('导入成功');
     for (const jp in importedGlossary)
       glossary.value[jp] = importedGlossary[jp];
+    loadGroups();
   }
 };
 
@@ -487,19 +546,21 @@ const submitGlossary = () =>
           />
 
           <!-- 单向同步按钮 -->
-          <n-divider vertical />
-          <c-button
-            label="远程→本地"
-            :round="false"
-            size="small"
-            @action="syncRemoteToLocal"
-          />
-          <c-button
-            label="本地→编辑区"
-            :round="false"
-            size="small"
-            @action="syncLocalToEditing"
-          />
+          <template v-if="!isNarrow">
+            <n-divider vertical />
+            <c-button
+              label="远程→本地"
+              :round="false"
+              size="small"
+              @action="syncRemoteToLocal"
+            />
+            <c-button
+              label="本地→编辑区"
+              :round="false"
+              size="small"
+              @action="syncLocalToEditing"
+            />
+          </template>
 
           <c-button
             v-if="whoami.isAdmin"
@@ -538,30 +599,19 @@ const submitGlossary = () =>
       </n-flex>
     </template>
 
-    <!-- 主内容区：左侧分组 + 右侧术语（桌面端） / 上标签栏 + 下内容（移动端） -->
-    <div
-      v-if="novelId"
-      :style="{
-        display: 'flex',
-        flexDirection: isNarrow ? 'column' : 'row',
-        gap: '12px',
-        minHeight: '300px',
-      }"
-      @keydown="onKeydown"
-    >
-      <!-- ======== 分组选择器 ======== -->
-      <!-- 桌面端：纵向侧边栏 -->
+    <!-- 主内容区 -->
+    <div v-if="novelId" @keydown="onKeydown">
+      <!-- ======== 桌面端：标签页 + 表格 ======== -->
       <div
         v-if="!isNarrow"
-        style="
-          width: 150px;
-          flex-shrink: 0;
-          border-right: 1px solid #eee;
-          padding-right: 8px;
-        "
+        :style="{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '12px',
+          minHeight: '300px',
+        }"
       >
-        <n-flex vertical size="small">
-          <n-text strong style="font-size: 13px">分组</n-text>
+        <div style="padding-bottom: 4px; border-bottom: 1px solid #eee">
           <GlossaryGroupTabs
             :group-names="groupNames"
             :display-data="displayData"
@@ -584,101 +634,85 @@ const submitGlossary = () =>
             @update:new-group-name="newGroupName = $event"
             @show-new-group="showNewGroupInput = true"
             @delete-group="deleteCurrentGroup"
+            @drop-term="onDropTerm"
+            @delete-group-request="onDeleteGroupRequest"
+            @reorder-groups="onReorderGroups"
           />
-        </n-flex>
+        </div>
+
+        <div style="flex: 1; min-width: 0">
+          <template v-if="selectedGroup && currentGroupEntries.length > 0">
+            <GlossaryTermTable
+              :entries="currentGroupEntries"
+              :glossary="glossary"
+              :selected-terms="selectedTerms"
+              :is-in-server-glossary="isInServerGlossary"
+              :is-zh-conflict="isZhConflict"
+              :get-local-zh="getLocalZh"
+              :novel-id="novelId"
+              :in-group="true"
+              @toggle-select="toggleSelect"
+              @delete-term="deleteTerm"
+              @remove-from-group="removeTermFromCurrentGroup"
+              @revert-term="revertTerm"
+              @revert-to-local-zh="revertToLocalZh"
+              @clear-local-record="clearLocalRecord"
+            />
+          </template>
+
+          <template v-else-if="!selectedGroup && ungroupedEntries.length > 0">
+            <GlossaryTermTable
+              :entries="ungroupedEntries"
+              :glossary="glossary"
+              :selected-terms="selectedTerms"
+              :is-in-server-glossary="isInServerGlossary"
+              :is-zh-conflict="isZhConflict"
+              :get-local-zh="getLocalZh"
+              :novel-id="novelId"
+              :in-group="false"
+              @toggle-select="toggleSelect"
+              @delete-term="deleteTerm"
+              @remove-from-group="removeTermFromCurrentGroup"
+              @revert-term="revertTerm"
+              @revert-to-local-zh="revertToLocalZh"
+              @clear-local-record="clearLocalRecord"
+            />
+          </template>
+
+          <n-text v-else depth="3" style="font-size: 12px">暂无术语</n-text>
+        </div>
       </div>
 
-      <!-- 移动端：横向滚动标签栏 -->
-      <div
-        v-else
-        style="
-          overflow-x: auto;
-          white-space: nowrap;
-          padding-bottom: 4px;
-          border-bottom: 1px solid #eee;
-        "
-      >
-        <n-flex align="center" style="flex-wrap: nowrap; gap: 4px">
-          <GlossaryGroupTabs
-            :group-names="groupNames"
-            :display-data="displayData"
-            :selected-group="selectedGroup"
-            :editing-group-name="editingGroupName"
-            :editing-group-new-name="editingGroupNewName"
-            :show-new-group-input="showNewGroupInput"
-            :new-group-name="newGroupName"
-            :ungrouped-count="ungroupedEntries.length"
-            @select="
-              (name) => {
-                selectedGroup = name;
-                clearSelection();
-              }
-            "
-            @start-rename="startRename"
-            @finish-rename="finishRename"
-            @update:editing-group-new-name="editingGroupNewName = $event"
-            @add-new-group="addNewGroup"
-            @update:new-group-name="newGroupName = $event"
-            @show-new-group="showNewGroupInput = true"
-            @delete-group="deleteCurrentGroup"
-          />
-        </n-flex>
-      </div>
-
-      <!-- ======== 术语列表 ======== -->
-      <div style="flex: 1; min-width: 0">
-        <template v-if="selectedGroup && currentGroupEntries.length > 0">
-          <n-text
-            depth="3"
-            style="font-size: 11px; margin-bottom: 8px; display: block"
-          >
-            分组: {{ selectedGroup }}
-          </n-text>
-          <GlossaryTermTable
-            :entries="currentGroupEntries"
-            :glossary="glossary"
-            :selected-terms="selectedTerms"
-            :is-in-server-glossary="isInServerGlossary"
-            :is-zh-conflict="isZhConflict"
-            :get-local-zh="getLocalZh"
-            :novel-id="novelId"
-            :in-group="true"
-            @toggle-select="toggleSelect"
-            @delete-term="deleteTerm"
-            @move-to-group="moveTermToGroup"
-            @remove-from-group="removeTermFromCurrentGroup"
-            @revert-term="revertTerm"
-            @revert-to-local-zh="revertToLocalZh"
-            @clear-local-record="clearLocalRecord"
-          />
-        </template>
-
-        <template v-else-if="!selectedGroup && ungroupedEntries.length > 0">
-          <n-text
-            depth="3"
-            style="font-size: 11px; margin-bottom: 8px; display: block"
-          >
-            未分组术语 — 点击分组名将术语移入分组
-          </n-text>
-          <GlossaryTermTable
-            :entries="ungroupedEntries"
-            :glossary="glossary"
-            :selected-terms="selectedTerms"
-            :is-in-server-glossary="isInServerGlossary"
-            :is-zh-conflict="isZhConflict"
-            :get-local-zh="getLocalZh"
-            :novel-id="novelId"
-            :in-group="false"
-            @toggle-select="toggleSelect"
-            @delete-term="deleteTerm"
-            @move-to-group="moveTermToGroup"
-            @remove-from-group="removeTermFromCurrentGroup"
-            @revert-term="revertTerm"
-            @revert-to-local-zh="revertToLocalZh"
-            @clear-local-record="clearLocalRecord"
-          />
-        </template>
-
+      <!-- ======== 移动端：简易表格（不启用分组） ======== -->
+      <div v-else>
+        <n-table
+          v-if="Object.keys(glossary).length !== 0"
+          striped
+          size="small"
+          style="font-size: 12px; max-width: 400px"
+        >
+          <tr v-for="wordJp in Object.keys(glossary).reverse()" :key="wordJp">
+            <td>
+              <c-button
+                :icon="DeleteOutlineOutlined"
+                text
+                type="error"
+                size="small"
+                @action="deleteTerm(wordJp)"
+              />
+            </td>
+            <td>{{ wordJp }}</td>
+            <td nowrap="nowrap">=></td>
+            <td style="padding-right: 16px">
+              <n-input
+                v-model:value="glossary[wordJp]"
+                size="tiny"
+                placeholder="请输入中文翻译"
+                :theme-overrides="{ border: '0', color: 'transprent' }"
+              />
+            </td>
+          </tr>
+        </n-table>
         <n-text v-else depth="3" style="font-size: 12px">暂无术语</n-text>
       </div>
     </div>
@@ -720,21 +754,37 @@ const submitGlossary = () =>
     </template>
   </c-modal>
 
+  <!-- 删除非空分组确认对话框 -->
+  <c-modal v-model:show="showDeleteGroupConfirm" title="确认删除分组">
+    <n-text>
+      分组 "{{ deleteGroupConfirmName }}" 中有
+      {{ deleteGroupConfirmCount }} 个术语，删除分组后这些术语将移到未分组。
+    </n-text>
+    <template #action>
+      <c-button label="取消" @action="deleteGroupConfirmName = null" />
+      <c-button label="确认删除" type="error" @action="confirmDeleteGroup" />
+    </template>
+  </c-modal>
+
   <!-- 清空确认对话框 -->
-  <n-modal v-model:show="showClearConfirm" title="确认清空">
-    <div style="padding: 16px">
-      <n-text>确定要清空术语表吗？此操作将同时清空本地分组数据。</n-text>
-      <n-flex justify="end" style="margin-top: 16px">
-        <c-button label="取消" @action="showClearConfirm = false" />
-        <c-button
-          label="确认清空"
-          type="error"
-          @action="
-            clearTerm();
-            showClearConfirm = false;
-          "
-        />
-      </n-flex>
-    </div>
-  </n-modal>
+  <c-modal v-model:show="showClearConfirm" title="确认清空">
+    <n-text>确定要清空术语表吗？此操作将同时清空本地分组数据。</n-text>
+    <template #action>
+      <c-button label="取消" @action="showClearConfirm = false" />
+      <c-button
+        label="确认清空"
+        type="error"
+        @action="
+          clearTerm();
+          showClearConfirm = false;
+        "
+      />
+    </template>
+  </c-modal>
 </template>
+
+<style scoped>
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -1,12 +1,18 @@
 <script lang="ts" setup>
-import { DeleteOutlineOutlined } from '@vicons/material';
+import { DeleteOutlineOutlined, AddOutlined } from '@vicons/material';
 
 import { WebNovelApi, WenkuNovelApi } from '@/api';
 import { GenericNovelId } from '@/model/Common';
 import { Glossary } from '@/model/Glossary';
+import {
+  GlossaryGroup,
+  type GlossaryGroupMap,
+  type GlossaryEntry,
+} from '@/model/GlossaryGroup';
 import { copyToClipBoard, doAction } from '@/pages/util';
 import { useLocalVolumeStore, useWhoamiStore } from '@/stores';
 import { downloadFile } from '@/util';
+import GlossaryTermTable from './GlossaryTermTable.vue';
 
 const props = defineProps<{
   gnid?: GenericNovelId;
@@ -22,27 +28,359 @@ const glossary = ref<Glossary>({});
 
 const showGlossaryModal = ref(false);
 
+const novelId = computed(() => {
+  const gnid = props.gnid;
+  if (!gnid) return '';
+  return GenericNovelId.toString(gnid);
+});
+
 const toggleGlossaryModal = () => {
   if (showGlossaryModal.value === false) {
     glossary.value = { ...props.value };
+    loadGroups();
+    selectedGroup.value = undefined;
+    selectedTerms.value = new Set();
   }
   showGlossaryModal.value = !showGlossaryModal.value;
 };
 
+// ========== 分组相关 ==========
+const groups = ref<GlossaryGroupMap>({});
+const selectedGroup = ref<string | undefined>(undefined);
+const newGroupName = ref('');
+const showNewGroupInput = ref(false);
+const editingGroupName = ref<string | null>(null);
+const editingGroupNewName = ref('');
+
+function loadGroups() {
+  if (!novelId.value) return;
+  groups.value = GlossaryGroup.getGroups(novelId.value);
+}
+
+function saveGroups() {
+  if (!novelId.value) return;
+  GlossaryGroup.saveGroups(novelId.value, groups.value);
+}
+
+// 监听跨标签页变更
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (
+      e.key === GlossaryGroup.storageKeyFor(novelId.value) &&
+      e.newValue !== null
+    ) {
+      try {
+        groups.value = JSON.parse(e.newValue);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+}
+
+const displayData = computed<GlossaryGroupMap>(() => {
+  if (!novelId.value) {
+    const result: GlossaryGroupMap = {};
+    result['未分组'] = Object.entries(glossary.value).map(([jp, zh]) => ({
+      jp,
+      zh,
+    }));
+    return result;
+  }
+  return GlossaryGroup.buildDisplayData(groups.value, glossary.value);
+});
+
+const groupNames = computed(() => {
+  return Object.keys(displayData.value).filter((n) => n !== '未分组');
+});
+
+const currentGroupEntries = computed<GlossaryEntry[]>(() => {
+  const name = selectedGroup.value;
+  if (!name) return [];
+  return displayData.value[name] ?? [];
+});
+
+const ungroupedEntries = computed<GlossaryEntry[]>(() => {
+  return displayData.value['未分组'] ?? [];
+});
+
+function isInServerGlossary(jp: string): boolean {
+  return jp in glossary.value;
+}
+
+function getLocalZh(jp: string): string | undefined {
+  if (!novelId.value) return undefined;
+  const g = GlossaryGroup.getGroups(novelId.value);
+  for (const entries of Object.values(g)) {
+    const found = entries.find((e) => e.jp === jp);
+    if (found) return found.zh;
+  }
+  return undefined;
+}
+
+function isZhConflict(jp: string): boolean {
+  const localZh = getLocalZh(jp);
+  return localZh !== undefined && localZh !== glossary.value[jp];
+}
+
+function addNewGroup() {
+  const name = newGroupName.value.trim();
+  if (!name) return;
+  if (name === '未分组') {
+    message.warning('不能使用保留名称');
+    return;
+  }
+  if (groups.value[name]) {
+    message.warning('分组名已存在');
+    return;
+  }
+  groups.value[name] = [];
+  saveGroups();
+  newGroupName.value = '';
+  showNewGroupInput.value = false;
+}
+
+function startRename(groupName: string) {
+  editingGroupName.value = groupName;
+  editingGroupNewName.value = groupName;
+}
+
+function finishRename() {
+  const oldName = editingGroupName.value;
+  const newName = editingGroupNewName.value.trim();
+  if (oldName && newName && oldName !== newName) {
+    if (newName === '未分组') {
+      message.warning('不能使用保留名称');
+    } else if (groups.value[newName]) {
+      message.warning('分组名已存在');
+    } else {
+      GlossaryGroup.renameGroup(novelId.value, oldName, newName);
+      loadGroups();
+      if (selectedGroup.value === oldName) selectedGroup.value = newName;
+    }
+  }
+  editingGroupName.value = null;
+  editingGroupNewName.value = '';
+}
+
+function deleteCurrentGroup() {
+  const name = selectedGroup.value;
+  if (!name) return;
+  GlossaryGroup.deleteGroup(novelId.value, name);
+  loadGroups();
+  selectedGroup.value = undefined;
+}
+
+function moveTermToGroup(jp: string) {
+  const name = selectedGroup.value;
+  if (!name || name === '未分组' || !novelId.value) return;
+  const zh = glossary.value[jp] ?? getLocalZh(jp) ?? '';
+  GlossaryGroup.moveTerm(novelId.value, jp, zh, name);
+  loadGroups();
+}
+
+function removeTermFromCurrentGroup(jp: string) {
+  if (!novelId.value) return;
+  GlossaryGroup.removeTerm(novelId.value, jp);
+  loadGroups();
+}
+
+// ========== 多选相关 ==========
+const selectedTerms = ref<Set<string>>(new Set());
+const lastClickedJp = ref<string | null>(null);
+
+function toggleSelect(jp: string, event: MouseEvent) {
+  if (event.ctrlKey || event.metaKey) {
+    const next = new Set(selectedTerms.value);
+    if (next.has(jp)) next.delete(jp);
+    else next.add(jp);
+    selectedTerms.value = next;
+    lastClickedJp.value = jp;
+  } else if (event.shiftKey && lastClickedJp.value) {
+    const entries = currentListEntries();
+    const prevIdx = entries.findIndex((e) => e.jp === lastClickedJp.value);
+    const curIdx = entries.findIndex((e) => e.jp === jp);
+    if (prevIdx >= 0 && curIdx >= 0) {
+      const start = Math.min(prevIdx, curIdx);
+      const end = Math.max(prevIdx, curIdx);
+      const next = new Set(selectedTerms.value);
+      for (let i = start; i <= end; i++) next.add(entries[i].jp);
+      selectedTerms.value = next;
+    }
+  } else {
+    selectedTerms.value = new Set([jp]);
+    lastClickedJp.value = jp;
+  }
+}
+
+function currentListEntries(): GlossaryEntry[] {
+  if (selectedGroup.value) return currentGroupEntries.value;
+  return ungroupedEntries.value;
+}
+
+function clearSelection() {
+  selectedTerms.value = new Set();
+  lastClickedJp.value = null;
+}
+
+function batchDeleteSelected() {
+  const toDelete = [...selectedTerms.value].filter((jp) =>
+    isInServerGlossary(jp),
+  );
+  if (toDelete.length === 0) return;
+  for (const jp of toDelete) {
+    deletedTerms.value.push([jp, glossary.value[jp]]);
+    delete glossary.value[jp];
+  }
+  if (novelId.value) {
+    for (const jp of toDelete) GlossaryGroup.removeTerm(novelId.value, jp);
+    loadGroups();
+  }
+  clearSelection();
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Delete' && selectedTerms.value.size > 0) {
+    batchDeleteSelected();
+  }
+  if (e.key === 'Escape') {
+    clearSelection();
+  }
+}
+
+// ========== 单向同步 ==========
+/** 远程 → 本地：用服务端术语表覆盖当前编辑 */
+function syncRemoteToLocal() {
+  glossary.value = { ...props.value };
+  message.success('已从远程同步到本地编辑');
+}
+
+/** 本地 → 编辑区：将本地分组中缓存的 zh 批量写入当前编辑术语表 */
+function syncLocalToEditing() {
+  if (!novelId.value) return;
+  let count = 0;
+  const localGroups = GlossaryGroup.getGroups(novelId.value);
+  for (const entries of Object.values(localGroups)) {
+    for (const e of entries) {
+      if (e.jp in glossary.value && glossary.value[e.jp] !== e.zh) {
+        glossary.value[e.jp] = e.zh;
+        count++;
+      }
+    }
+  }
+  message.success(`已将 ${count} 条本地 zh 同步到编辑区`);
+}
+
+// ========== 术语 CRUD ==========
+const importGlossaryRaw = ref('');
+const termsToAdd = ref<[string, string]>(['', '']);
+const deletedTerms = ref<[string, string][]>([]);
+
+const lastDeletedTerm = computed(() => {
+  const last = deletedTerms.value[deletedTerms.value.length - 1];
+  if (last === undefined) return undefined;
+  return `${last[0]} => ${last[1]}`;
+});
+
+const clearTerm = () => {
+  glossary.value = {};
+  if (novelId.value) GlossaryGroup.clearGroups(novelId.value);
+  loadGroups();
+};
+
+const showClearConfirm = ref(false);
+
+const undoDeleteTerm = () => {
+  if (deletedTerms.value.length === 0) return;
+  const [jp, zh] = deletedTerms.value.pop()!;
+  glossary.value[jp] = zh;
+};
+
+const deleteTerm = (jp: string) => {
+  if (jp in glossary.value) {
+    deletedTerms.value.push([jp, glossary.value[jp]]);
+    delete glossary.value[jp];
+  }
+};
+
+const revertTerm = (jp: string) => {
+  if (!novelId.value) return;
+  const g = GlossaryGroup.getGroups(novelId.value);
+  for (const [, entries] of Object.entries(g)) {
+    const found = entries.find((e) => e.jp === jp);
+    if (found) {
+      glossary.value[jp] = found.zh;
+      if (selectedGroup.value && selectedGroup.value !== '未分组') {
+        GlossaryGroup.moveTerm(
+          novelId.value,
+          jp,
+          found.zh,
+          selectedGroup.value,
+        );
+      } else {
+        GlossaryGroup.removeTerm(novelId.value, jp);
+      }
+      loadGroups();
+      return;
+    }
+  }
+};
+
+const revertToLocalZh = (jp: string) => {
+  const localZh = getLocalZh(jp);
+  if (localZh !== undefined) glossary.value[jp] = localZh;
+};
+
+const clearLocalRecord = (jp: string) => {
+  if (!novelId.value) return;
+  GlossaryGroup.removeTerm(novelId.value, jp);
+  loadGroups();
+};
+
+const addTerm = () => {
+  const [jp, zh] = termsToAdd.value;
+  if (jp && zh) {
+    glossary.value[jp.trim()] = zh.trim();
+    termsToAdd.value = ['', ''];
+  }
+};
+
+const exportGlossary = async (ev: MouseEvent) => {
+  const isSuccess = await copyToClipBoard(
+    Glossary.toText(glossary.value),
+    ev.target as HTMLElement,
+  );
+  if (isSuccess) message.success('导出成功：已复制到剪贴板');
+  else message.error('导出失败');
+};
+
+const importGlossary = () => {
+  const importedGlossary = Glossary.fromText(importGlossaryRaw.value);
+  if (importedGlossary === undefined) {
+    message.error('导入失败：术语表格式不正确');
+  } else {
+    message.success('导入成功');
+    for (const jp in importedGlossary)
+      glossary.value[jp] = importedGlossary[jp];
+  }
+};
+
+const downloadGlossaryAsJsonFile = async () => {
+  downloadFile(
+    `${gnidHint.value ?? 'glossary'}.json`,
+    new Blob([Glossary.toJson(glossary.value)], { type: 'text/plain' }),
+  );
+};
+
 const gnidHint = computed(() => {
   const gnid = props.gnid;
-  if (gnid === undefined) {
-    return undefined;
-  } else {
-    return GenericNovelId.toString(gnid);
-  }
+  if (gnid === undefined) return undefined;
+  return GenericNovelId.toString(gnid);
 });
 
 const updateGlossary = async () => {
   const gnid = props.gnid;
-  if (gnid === undefined) {
-    return;
-  }
+  if (gnid === undefined) return;
   const glossaryValue = toRaw(glossary.value);
   if (gnid.type === 'web') {
     await WebNovelApi.updateGlossary(
@@ -61,87 +399,13 @@ const updateGlossary = async () => {
 const submitGlossary = () =>
   doAction(
     updateGlossary().then(() => {
-      // 触发组件外的术语表本体更新。有点傻，但够用。
-      for (const key in props.value) {
-        delete props.value[key];
-      }
-      for (const key in glossary.value) {
-        props.value[key] = glossary.value[key];
-      }
+      for (const key in props.value) delete props.value[key];
+      for (const key in glossary.value) props.value[key] = glossary.value[key];
+      if (novelId.value) saveGroups();
     }),
     '术语表提交',
     message,
   );
-
-const importGlossaryRaw = ref('');
-const termsToAdd = ref<[string, string]>(['', '']);
-
-const deletedTerms = ref<[string, string][]>([]);
-
-const lastDeletedTerm = computed(() => {
-  const last = deletedTerms.value[deletedTerms.value.length - 1];
-  if (last === undefined) return undefined;
-  return `${last[0]} => ${last[1]}`;
-});
-
-const clearTerm = () => {
-  glossary.value = {};
-};
-
-const undoDeleteTerm = () => {
-  if (deletedTerms.value.length === 0) return;
-  const [jp, zh] = deletedTerms.value.pop()!;
-  glossary.value[jp] = zh;
-};
-
-const deleteTerm = (jp: string) => {
-  if (jp in glossary.value) {
-    deletedTerms.value.push([jp, glossary.value[jp]]);
-    delete glossary.value[jp];
-  }
-};
-
-const addTerm = () => {
-  const [jp, zh] = termsToAdd.value;
-  if (jp && zh) {
-    glossary.value[jp.trim()] = zh.trim();
-    termsToAdd.value = ['', ''];
-  }
-};
-
-const exportGlossary = async (ev: MouseEvent) => {
-  const isSuccess = await copyToClipBoard(
-    Glossary.toText(glossary.value),
-    ev.target as HTMLElement,
-  );
-  if (isSuccess) {
-    message.success('导出成功：已复制到剪贴板');
-  } else {
-    message.success('导出失败');
-  }
-};
-
-const importGlossary = () => {
-  const importedGlossary = Glossary.fromText(importGlossaryRaw.value);
-  if (importedGlossary === undefined) {
-    message.error('导入失败：术语表格式不正确');
-  } else {
-    message.success('导入成功');
-    for (const jp in importedGlossary) {
-      const zh = importedGlossary[jp];
-      glossary.value[jp] = zh;
-    }
-  }
-};
-
-const downloadGlossaryAsJsonFile = async (ev: MouseEvent) => {
-  downloadFile(
-    `${gnidHint.value ?? 'glossary'}.json`,
-    new Blob([Glossary.toJson(glossary.value)], {
-      type: 'text/plain',
-    }),
-  );
-};
 </script>
 
 <template>
@@ -160,11 +424,10 @@ const downloadGlossaryAsJsonFile = async (ev: MouseEvent) => {
       <n-flex
         vertical
         size="large"
-        style="max-width: 400px; margin-bottom: 16px"
+        style="max-width: 600px; margin-bottom: 16px"
       >
         <template v-if="gnidHint">
           <n-text style="font-size: 12px">{{ gnidHint }}</n-text>
-
           <n-text>
             使用前务必先阅读
             <c-a to="/forum/660ab4da55001f583649a621">术语表使用指南</c-a>
@@ -212,11 +475,27 @@ const downloadGlossaryAsJsonFile = async (ev: MouseEvent) => {
             @action="importGlossary"
           />
           <c-button
-            label="下载json文件"
+            label="下载json"
             :round="false"
             size="small"
             @action="downloadGlossaryAsJsonFile"
           />
+
+          <!-- 单向同步按钮 -->
+          <n-divider vertical />
+          <c-button
+            label="远程→本地"
+            :round="false"
+            size="small"
+            @action="syncRemoteToLocal"
+          />
+          <c-button
+            label="本地→编辑区"
+            :round="false"
+            size="small"
+            @action="syncLocalToEditing"
+          />
+
           <c-button
             v-if="whoami.isAdmin"
             secondary
@@ -224,9 +503,10 @@ const downloadGlossaryAsJsonFile = async (ev: MouseEvent) => {
             label="清空"
             :round="false"
             size="small"
-            @action="clearTerm"
+            @action="showClearConfirm = true"
           />
         </n-flex>
+
         <n-flex align="center" :wrap="false">
           <c-button
             :disabled="deletedTerms.length === 0"
@@ -242,44 +522,236 @@ const downloadGlossaryAsJsonFile = async (ev: MouseEvent) => {
           >
             {{ lastDeletedTerm }}
           </n-text>
+          <n-text
+            v-if="selectedTerms.size > 0"
+            depth="3"
+            style="font-size: 12px; margin-left: 8px"
+          >
+            已选 {{ selectedTerms.size }} 项 — Delete 键批量删除
+          </n-text>
         </n-flex>
       </n-flex>
     </template>
 
-    <n-table
-      v-if="Object.keys(glossary).length !== 0"
-      striped
-      size="small"
-      style="font-size: 12px; max-width: 400px"
+    <!-- 主内容区：左侧分组 + 右侧术语 -->
+    <div
+      v-if="novelId"
+      style="display: flex; gap: 16px; min-height: 300px"
+      @keydown="onKeydown"
     >
-      <tr v-for="wordJp in Object.keys(glossary).reverse()" :key="wordJp">
-        <td>
+      <!-- 左侧分组侧边栏 -->
+      <div
+        style="
+          width: 150px;
+          flex-shrink: 0;
+          border-right: 1px solid #eee;
+          padding-right: 8px;
+        "
+      >
+        <n-flex vertical size="small">
+          <n-text strong style="font-size: 13px">分组</n-text>
+
+          <div
+            v-for="name in groupNames"
+            :key="name"
+            @click="
+              selectedGroup = name;
+              clearSelection();
+            "
+            :style="{
+              padding: '4px 8px',
+              cursor: 'pointer',
+              borderRadius: '4px',
+              fontSize: '12px',
+              background:
+                selectedGroup === name
+                  ? 'var(--primary-color-hover, #eee)'
+                  : 'transparent',
+            }"
+          >
+            <template v-if="editingGroupName === name">
+              <n-input
+                v-model:value="editingGroupNewName"
+                size="tiny"
+                @blur="finishRename"
+                @keydown.enter="finishRename"
+              />
+            </template>
+            <template v-else>
+              <n-flex justify="space-between" align="center">
+                <n-text @dblclick="startRename(name)" style="flex: 1">
+                  {{ name }}
+                </n-text>
+                <n-text depth="3" style="font-size: 10px">
+                  {{ displayData[name]?.length ?? 0 }}
+                </n-text>
+              </n-flex>
+            </template>
+          </div>
+
+          <div
+            @click="
+              selectedGroup = undefined;
+              clearSelection();
+            "
+            :style="{
+              padding: '4px 8px',
+              cursor: 'pointer',
+              borderRadius: '4px',
+              fontSize: '12px',
+              background:
+                selectedGroup === undefined
+                  ? 'var(--primary-color-hover, #eee)'
+                  : 'transparent',
+            }"
+          >
+            <n-flex justify="space-between" align="center">
+              <n-text>未分组</n-text>
+              <n-text depth="3" style="font-size: 10px">
+                {{ ungroupedEntries.length }}
+              </n-text>
+            </n-flex>
+          </div>
+
+          <div v-if="showNewGroupInput" style="margin-top: 4px">
+            <n-input
+              v-model:value="newGroupName"
+              size="tiny"
+              placeholder="新分组名"
+              @keydown.enter="addNewGroup"
+              @blur="addNewGroup"
+            />
+          </div>
           <c-button
-            :icon="DeleteOutlineOutlined"
+            v-else
+            :icon="AddOutlined"
+            label="新建组"
+            size="tiny"
+            text
+            @action="showNewGroupInput = true"
+          />
+
+          <c-button
+            v-if="selectedGroup && selectedGroup !== '未分组'"
+            label="删除此组"
+            size="tiny"
             text
             type="error"
-            size="small"
-            @action="deleteTerm(wordJp)"
+            @action="deleteCurrentGroup"
           />
-        </td>
-        <td>{{ wordJp }}</td>
-        <td nowrap="nowrap">=></td>
-        <td style="padding-right: 16px">
-          <n-input
-            v-model:value="glossary[wordJp]"
-            size="tiny"
-            placeholder="请输入中文翻译"
-            :theme-overrides="{
-              border: '0',
-              color: 'transprent',
-            }"
+        </n-flex>
+      </div>
+
+      <!-- 右侧术语列表 -->
+      <div style="flex: 1; min-width: 0">
+        <template v-if="selectedGroup && currentGroupEntries.length > 0">
+          <n-text
+            depth="3"
+            style="font-size: 11px; margin-bottom: 8px; display: block"
+          >
+            分组: {{ selectedGroup }}
+          </n-text>
+          <GlossaryTermTable
+            :entries="currentGroupEntries"
+            :glossary="glossary"
+            :selected-terms="selectedTerms"
+            :is-in-server-glossary="isInServerGlossary"
+            :is-zh-conflict="isZhConflict"
+            :get-local-zh="getLocalZh"
+            :novel-id="novelId"
+            :in-group="true"
+            @toggle-select="toggleSelect"
+            @delete-term="deleteTerm"
+            @move-to-group="moveTermToGroup"
+            @remove-from-group="removeTermFromCurrentGroup"
+            @revert-term="revertTerm"
+            @revert-to-local-zh="revertToLocalZh"
+            @clear-local-record="clearLocalRecord"
           />
-        </td>
-      </tr>
-    </n-table>
+        </template>
+
+        <template v-else-if="!selectedGroup && ungroupedEntries.length > 0">
+          <n-text
+            depth="3"
+            style="font-size: 11px; margin-bottom: 8px; display: block"
+          >
+            未分组术语 — 点击左侧分组名将术语移入分组
+          </n-text>
+          <GlossaryTermTable
+            :entries="ungroupedEntries"
+            :glossary="glossary"
+            :selected-terms="selectedTerms"
+            :is-in-server-glossary="isInServerGlossary"
+            :is-zh-conflict="isZhConflict"
+            :get-local-zh="getLocalZh"
+            :novel-id="novelId"
+            :in-group="false"
+            @toggle-select="toggleSelect"
+            @delete-term="deleteTerm"
+            @move-to-group="moveTermToGroup"
+            @remove-from-group="removeTermFromCurrentGroup"
+            @revert-term="revertTerm"
+            @revert-to-local-zh="revertToLocalZh"
+            @clear-local-record="clearLocalRecord"
+          />
+        </template>
+
+        <n-text v-else depth="3" style="font-size: 12px">暂无术语</n-text>
+      </div>
+    </div>
+
+    <!-- 无 novelId 时的降级视图 -->
+    <div v-else>
+      <n-table
+        v-if="Object.keys(glossary).length !== 0"
+        striped
+        size="small"
+        style="font-size: 12px; max-width: 400px"
+      >
+        <tr v-for="wordJp in Object.keys(glossary).reverse()" :key="wordJp">
+          <td>
+            <c-button
+              :icon="DeleteOutlineOutlined"
+              text
+              type="error"
+              size="small"
+              @action="deleteTerm(wordJp)"
+            />
+          </td>
+          <td>{{ wordJp }}</td>
+          <td nowrap="nowrap">=></td>
+          <td style="padding-right: 16px">
+            <n-input
+              v-model:value="glossary[wordJp]"
+              size="tiny"
+              placeholder="请输入中文翻译"
+              :theme-overrides="{ border: '0', color: 'transprent' }"
+            />
+          </td>
+        </tr>
+      </n-table>
+    </div>
 
     <template #action>
       <c-button label="提交" type="primary" @action="submitGlossary()" />
     </template>
   </c-modal>
+
+  <!-- 清空确认对话框 -->
+  <n-modal v-model:show="showClearConfirm" title="确认清空">
+    <div style="padding: 16px">
+      <n-text>确定要清空术语表吗？此操作将同时清空本地分组数据。</n-text>
+      <n-flex justify="end" style="margin-top: 16px">
+        <c-button label="取消" @action="showClearConfirm = false" />
+        <c-button
+          label="确认清空"
+          type="error"
+          @action="
+            clearTerm();
+            showClearConfirm = false;
+          "
+        />
+      </n-flex>
+    </div>
+  </n-modal>
 </template>

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -9,6 +9,14 @@ import {
   type GlossaryGroupMap,
   type GlossaryEntry,
 } from '@/model/GlossaryGroup';
+import {
+  type GlossaryHistoryEntry,
+  getHistory,
+  addHistory,
+  deleteHistory,
+  clearHistory,
+  getLatestGlossary,
+} from '@/model/GlossaryHistory';
 import { copyToClipBoard, doAction } from '@/pages/util';
 import { useLocalVolumeStore, useSettingStore, useWhoamiStore } from '@/stores';
 import { downloadFile } from '@/util';
@@ -49,6 +57,15 @@ const toggleGlossaryModal = () => {
     loadGroups();
     selectedGroup.value = undefined;
     selectedTerms.value = new Set();
+
+    // 检测远程变动：如果服务端术语表与最近一条历史记录不同，自动写入快照
+    // addHistory 内部有去重，相同则跳过
+    if (novelId.value && Object.keys(props.value).length > 0) {
+      addHistory(novelId.value, {
+        glossary: { ...props.value },
+        type: 'remote-changed',
+      });
+    }
   }
   showGlossaryModal.value = !showGlossaryModal.value;
 };
@@ -389,6 +406,10 @@ const importGlossaryRaw = ref('');
 const termsToAdd = ref<[string, string]>(['', '']);
 const deletedTerms = ref<[string, string][]>([]);
 
+const deletedJps = computed(
+  () => new Set(deletedTerms.value.map(([jp]) => jp)),
+);
+
 const lastDeletedTerm = computed(() => {
   const last = deletedTerms.value[deletedTerms.value.length - 1];
   if (last === undefined) return undefined;
@@ -403,6 +424,71 @@ const clearTerm = () => {
 
 const showClearConfirm = ref(false);
 
+// ========== 历史记录 ==========
+const showHistoryModal = ref(false);
+const expandedHistoryId = ref<string | undefined>(undefined);
+const historyVersion = ref(0);
+
+const historyEntries = computed<GlossaryHistoryEntry[]>(() => {
+  if (!novelId.value) return [];
+  void historyVersion.value; // 强制在 openHistory 时刷新
+  return getHistory(novelId.value);
+});
+
+const historyCount = computed(() => historyEntries.value.length);
+
+function openHistory() {
+  historyVersion.value++;
+  showHistoryModal.value = true;
+}
+
+function restoreHistory(entry: GlossaryHistoryEntry) {
+  glossary.value = { ...entry.glossary };
+  if (novelId.value) loadGroups();
+  showHistoryModal.value = false;
+  message.success(
+    `已恢复到 ${new Date(entry.timestamp).toLocaleString()} 的历史版本`,
+  );
+}
+
+interface GlossaryDiff {
+  added: { jp: string; zh: string }[];
+  removed: { jp: string; zh: string }[];
+  modified: { jp: string; oldZh: string; newZh: string }[];
+  unchanged: { jp: string; zh: string }[];
+}
+
+function getHistoryDiff(entry: GlossaryHistoryEntry): GlossaryDiff {
+  const oldGlossary = entry.glossary;
+  const cur = glossary.value;
+  const added: GlossaryDiff['added'] = [];
+  const removed: GlossaryDiff['removed'] = [];
+  const modified: GlossaryDiff['modified'] = [];
+  const unchanged: GlossaryDiff['unchanged'] = [];
+
+  for (const jp of Object.keys(oldGlossary)) {
+    if (!(jp in cur)) {
+      removed.push({ jp, zh: oldGlossary[jp] });
+    } else if (cur[jp] !== oldGlossary[jp]) {
+      modified.push({ jp, oldZh: oldGlossary[jp], newZh: cur[jp] });
+    } else {
+      unchanged.push({ jp, zh: oldGlossary[jp] });
+    }
+  }
+  for (const jp of Object.keys(cur)) {
+    if (!(jp in oldGlossary)) {
+      added.push({ jp, zh: cur[jp] });
+    }
+  }
+
+  return { added, removed, modified, unchanged };
+}
+
+function deleteHistoryEntry(entryId: string) {
+  if (!novelId.value) return;
+  deleteHistory(novelId.value, entryId);
+}
+
 const undoDeleteTerm = () => {
   if (deletedTerms.value.length === 0) return;
   const [jp, zh] = deletedTerms.value.pop()!;
@@ -414,6 +500,7 @@ const deleteTerm = (jp: string) => {
   if (jp in glossary.value) {
     deletedTerms.value.push([jp, glossary.value[jp]]);
     delete glossary.value[jp];
+    if (novelId.value) GlossaryGroup.removeTerm(novelId.value, jp);
     loadGroups();
   }
 };
@@ -442,6 +529,8 @@ const clearLocalRecord = (jp: string) => {
   loadGroups();
 };
 
+const addJpInputRef = ref<{ focus: () => void }>();
+
 const addTerm = () => {
   const [jp, zh] = termsToAdd.value;
   if (jp && zh) {
@@ -450,6 +539,19 @@ const addTerm = () => {
     loadGroups();
   }
 };
+
+function onAddInputKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    const [jp, zh] = termsToAdd.value;
+    if (jp.trim() && zh.trim()) {
+      addTerm();
+      nextTick(() => {
+        addJpInputRef.value?.focus();
+      });
+    }
+  }
+}
 
 const exportGlossary = async (ev: MouseEvent) => {
   const isSuccess = await copyToClipBoard(
@@ -509,6 +611,12 @@ const submitGlossary = () =>
       for (const key in props.value) delete props.value[key];
       for (const key in glossary.value) props.value[key] = glossary.value[key];
       if (novelId.value) saveGroups();
+      if (novelId.value && Object.keys(glossary.value).length > 0) {
+        addHistory(novelId.value, {
+          glossary: { ...toRaw(glossary.value) },
+          type: 'submit',
+        });
+      }
     }),
     '术语表提交',
     message,
@@ -544,12 +652,14 @@ const submitGlossary = () =>
 
         <n-input-group>
           <n-input
+            ref="addJpInputRef"
             pair
             v-model:value="termsToAdd"
             size="small"
             separator="=>"
             :placeholder="['日文', '中文']"
-            :input-props="{ spellcheck: false }"
+            :input-props="[{ spellcheck: false }, { spellcheck: false }]"
+            @keydown="onAddInputKeydown"
           />
           <c-button
             label="添加"
@@ -635,6 +745,7 @@ const submitGlossary = () =>
             :new-group-name="newGroupName"
             :ungrouped-count="ungroupedEntries.length"
             :is-admin="whoami.isAdmin"
+            :history-count="historyCount"
             @sync-remote-to-local="syncRemoteToLocal"
             @sync-local-to-editing="syncLocalToEditing"
             @clear-request="showClearConfirm = true"
@@ -658,6 +769,7 @@ const submitGlossary = () =>
             @sort-by-time-reverse="handleSortByTimeReverse"
             @sort-by-kana="handleSortByKana"
             @sort-by-kana-reverse="handleSortByKanaReverse"
+            @show-history="openHistory"
           />
         </div>
 
@@ -673,6 +785,7 @@ const submitGlossary = () =>
               :novel-id="novelId"
               :in-group="true"
               :group-name="selectedGroup"
+              :deleted-jps="deletedJps"
               @toggle-select="toggleSelect"
               @delete-term="deleteTerm"
               @remove-from-group="removeTermFromCurrentGroup"
@@ -698,6 +811,7 @@ const submitGlossary = () =>
               :get-local-zh="getLocalZh"
               :novel-id="novelId"
               :in-group="false"
+              :deleted-jps="deletedJps"
               @toggle-select="toggleSelect"
               @delete-term="deleteTerm"
               @remove-from-group="removeTermFromCurrentGroup"
@@ -799,6 +913,164 @@ const submitGlossary = () =>
       <c-button label="确认删除" type="error" @action="confirmDeleteGroup" />
     </template>
   </c-modal>
+
+  <!-- 历史记录对话框 -->
+  <n-modal
+    v-model:show="showHistoryModal"
+    preset="card"
+    title="术语表历史记录"
+    :bordered="false"
+    size="large"
+    transform-origin="center"
+    :block-scroll="false"
+    style="width: min(600px, calc(100% - 16px))"
+  >
+    <n-text v-if="historyEntries.length === 0" depth="3">暂无历史记录</n-text>
+    <n-list v-else>
+      <n-list-item
+        v-for="entry in [...historyEntries].reverse()"
+        :key="entry.id"
+      >
+        <n-thing>
+          <template #header>
+            <n-flex align="center" :wrap="false">
+              <n-tag
+                :type="entry.type === 'submit' ? 'info' : 'warning'"
+                size="small"
+              >
+                {{ entry.type === 'submit' ? '提交' : '远程变动' }}
+              </n-tag>
+              <n-text depth="3" style="font-size: 12px">
+                {{ new Date(entry.timestamp).toLocaleString() }}
+              </n-text>
+              <n-text style="font-size: 12px">
+                {{ entry.termCount }} 条术语
+              </n-text>
+            </n-flex>
+          </template>
+          <template #description>
+            <template
+              v-for="diff in [
+                expandedHistoryId === entry.id ? getHistoryDiff(entry) : null,
+              ]"
+              :key="entry.id"
+            >
+              <div
+                v-if="diff"
+                style="max-height: 250px; overflow-y: auto; margin-top: 8px"
+              >
+                <div
+                  v-if="
+                    diff.removed.length +
+                      diff.modified.length +
+                      diff.added.length ===
+                    0
+                  "
+                >
+                  <n-text depth="3" style="font-size: 11px">
+                    与当前无差异
+                  </n-text>
+                </div>
+                <table
+                  v-else
+                  style="
+                    width: 100%;
+                    max-width: 500px;
+                    border-collapse: collapse;
+                    font-size: 11px;
+                    font-family: monospace;
+                  "
+                >
+                  <tr
+                    v-for="row in diff.removed"
+                    :key="'removed-' + row.jp"
+                    style="background: rgba(208, 48, 80, 0.1)"
+                  >
+                    <td style="width: 16px; color: #d03050; padding: 2px 4px">
+                      -
+                    </td>
+                    <td style="padding: 2px 4px">{{ row.jp }}</td>
+                    <td style="padding: 2px 4px">=></td>
+                    <td style="padding: 2px 4px; color: #d03050">
+                      {{ row.zh }}
+                    </td>
+                  </tr>
+                  <tr
+                    v-for="row in diff.modified"
+                    :key="'modified-' + row.jp"
+                    style="background: rgba(240, 160, 30, 0.1)"
+                  >
+                    <td style="width: 16px; color: #f0a01e; padding: 2px 4px">
+                      ~
+                    </td>
+                    <td style="padding: 2px 4px">{{ row.jp }}</td>
+                    <td style="padding: 2px 4px">=></td>
+                    <td style="padding: 2px 4px">
+                      <span style="text-decoration: line-through; opacity: 0.6">
+                        {{ row.oldZh }}
+                      </span>
+                      <span style="margin: 0 4px">→</span>
+                      <span style="color: #f0a01e">{{ row.newZh }}</span>
+                    </td>
+                  </tr>
+                  <tr
+                    v-for="row in diff.added"
+                    :key="'added-' + row.jp"
+                    style="background: rgba(24, 160, 88, 0.1)"
+                  >
+                    <td style="width: 16px; color: #18a058; padding: 2px 4px">
+                      +
+                    </td>
+                    <td style="padding: 2px 4px">{{ row.jp }}</td>
+                    <td style="padding: 2px 4px">=></td>
+                    <td style="padding: 2px 4px; color: #18a058">
+                      {{ row.zh }}
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </template>
+          </template>
+          <template #action>
+            <n-space>
+              <n-button
+                size="tiny"
+                @click="
+                  expandedHistoryId =
+                    expandedHistoryId === entry.id ? undefined : entry.id
+                "
+              >
+                展开
+              </n-button>
+              <n-button
+                size="tiny"
+                type="primary"
+                @click="restoreHistory(entry)"
+              >
+                恢复
+              </n-button>
+              <n-button size="tiny" @click="deleteHistoryEntry(entry.id)">
+                删除
+              </n-button>
+            </n-space>
+          </template>
+        </n-thing>
+      </n-list-item>
+    </n-list>
+    <template #action>
+      <n-button
+        v-if="historyEntries.length > 0"
+        type="error"
+        @click="
+          clearHistory(novelId);
+          showHistoryModal = false;
+        "
+      >
+        清空全部历史
+      </n-button>
+      <n-button @click="showHistoryModal = false">关闭</n-button>
+    </template>
+  </n-modal>
 
   <!-- 清空确认对话框 -->
   <c-modal v-model:show="showClearConfirm" title="确认清空">

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -49,7 +49,7 @@ const emit = defineEmits<{
   'update:newGroupName': [value: string];
   showNewGroup: [];
   deleteGroup: [];
-  dropTerm: [jp: string | string[], groupName: string | undefined];
+  dropTerm: [jp: string, groupName: string | undefined];
   deleteGroupRequest: [name: string];
   reorderGroups: [from: string, to: string];
   syncRemoteToLocal: [];
@@ -223,23 +223,10 @@ function onTabsDragLeave(e: DragEvent) {
 
 function onDrop(e: DragEvent, groupName: string | undefined) {
   e.preventDefault();
-  // 有 term 数据 → 优先走 term drop 逻辑
   const raw = e.dataTransfer?.getData('text/plain');
   if (raw) {
-    let jps: string | string[] = raw;
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) jps = parsed;
-    } catch {
-      /* not JSON, use raw string */
-    }
-    emit('dropTerm', jps, groupName);
-    draggedGroup.value = null;
-    dragOverGroup.value = undefined;
-    return;
-  }
-  // 无 term 数据 → tab reorder
-  if (draggedGroup.value && draggedGroup.value !== groupName) {
+    emit('dropTerm', raw, groupName);
+  } else if (draggedGroup.value && draggedGroup.value !== groupName) {
     let target = groupName ?? '';
     if (target) {
       target = resolveDropTarget(e.clientX, e.clientY, target);

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -55,6 +55,10 @@ const emit = defineEmits<{
   syncRemoteToLocal: [];
   syncLocalToEditing: [];
   clearRequest: [];
+  sortByTime: [];
+  sortByTimeReverse: [];
+  sortByKana: [];
+  sortByKanaReverse: [];
 }>();
 
 const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
@@ -147,6 +151,20 @@ function cancelLongPress() {
     clearTimeout(longPressTimer.value);
     longPressTimer.value = null;
   }
+}
+
+const sortOptions = [
+  { label: '时间排序', key: 'time' },
+  { label: '时间倒序', key: 'time-reverse' },
+  { label: '五十音排序 (A→Z)', key: 'kana' },
+  { label: '五十音倒序 (Z→A)', key: 'kana-reverse' },
+];
+
+function handleSortSelect(key: string) {
+  if (key === 'time') emit('sortByTime');
+  else if (key === 'time-reverse') emit('sortByTimeReverse');
+  else if (key === 'kana') emit('sortByKana');
+  else if (key === 'kana-reverse') emit('sortByKanaReverse');
 }
 
 function resolveDropTarget(
@@ -412,6 +430,15 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
         style="flex-shrink: 0"
         @action="emit('showNewGroup')"
       />
+
+      <!-- 排序 -->
+      <n-dropdown
+        trigger="click"
+        :options="sortOptions"
+        @select="handleSortSelect"
+      >
+        <c-button label="排序" size="tiny" text style="flex-shrink: 0" />
+      </n-dropdown>
 
       <!-- 删除当前组 -->
       <c-button

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -1,0 +1,116 @@
+<script lang="ts" setup>
+import { AddOutlined } from '@vicons/material';
+
+const props = defineProps<{
+  groupNames: string[];
+  displayData: Record<string, { jp: string; zh: string }[]>;
+  selectedGroup: string | undefined;
+  editingGroupName: string | null;
+  editingGroupNewName: string;
+  showNewGroupInput: boolean;
+  newGroupName: string;
+  ungroupedCount: number;
+}>();
+
+const emit = defineEmits<{
+  select: [name: string | undefined];
+  startRename: [name: string];
+  finishRename: [];
+  'update:editingGroupNewName': [value: string];
+  addNewGroup: [];
+  'update:newGroupName': [value: string];
+  showNewGroup: [];
+  deleteGroup: [];
+}>();
+</script>
+
+<template>
+  <!-- 用户分组列表 -->
+  <div
+    v-for="name in groupNames"
+    :key="name"
+    @click="emit('select', name)"
+    :style="{
+      padding: '4px 8px',
+      cursor: 'pointer',
+      borderRadius: '4px',
+      fontSize: '12px',
+      whiteSpace: 'nowrap',
+      background:
+        selectedGroup === name
+          ? 'var(--primary-color-hover, #eee)'
+          : 'transparent',
+    }"
+  >
+    <template v-if="editingGroupName === name">
+      <n-input
+        :value="editingGroupNewName"
+        size="tiny"
+        @update:value="emit('update:editingGroupNewName', $event)"
+        @blur="emit('finishRename')"
+        @keydown.enter="emit('finishRename')"
+      />
+    </template>
+    <template v-else>
+      <n-flex justify="space-between" align="center">
+        <n-text @dblclick="emit('startRename', name)" style="flex: 1">
+          {{ name }}
+        </n-text>
+        <n-text depth="3" style="font-size: 10px">
+          {{ displayData[name]?.length ?? 0 }}
+        </n-text>
+      </n-flex>
+    </template>
+  </div>
+
+  <!-- 未分组 -->
+  <div
+    @click="emit('select', undefined)"
+    :style="{
+      padding: '4px 8px',
+      cursor: 'pointer',
+      borderRadius: '4px',
+      fontSize: '12px',
+      whiteSpace: 'nowrap',
+      background:
+        selectedGroup === undefined
+          ? 'var(--primary-color-hover, #eee)'
+          : 'transparent',
+    }"
+  >
+    <n-flex justify="space-between" align="center">
+      <n-text>未分组</n-text>
+      <n-text depth="3" style="font-size: 10px">{{ ungroupedCount }}</n-text>
+    </n-flex>
+  </div>
+
+  <!-- 新建组 -->
+  <div v-if="showNewGroupInput" style="margin-top: 4px">
+    <n-input
+      :value="newGroupName"
+      size="tiny"
+      placeholder="新分组名"
+      @update:value="emit('update:newGroupName', $event)"
+      @keydown.enter="emit('addNewGroup')"
+      @blur="emit('addNewGroup')"
+    />
+  </div>
+  <c-button
+    v-else
+    :icon="AddOutlined"
+    label="新建组"
+    size="tiny"
+    text
+    @action="emit('showNewGroup')"
+  />
+
+  <!-- 删除当前组 -->
+  <c-button
+    v-if="selectedGroup && selectedGroup !== '未分组'"
+    label="删除此组"
+    size="tiny"
+    text
+    type="error"
+    @action="emit('deleteGroup')"
+  />
+</template>

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -33,6 +33,7 @@ const props = defineProps<{
   showNewGroupInput: boolean;
   newGroupName: string;
   ungroupedCount: number;
+  isAdmin: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -47,6 +48,9 @@ const emit = defineEmits<{
   dropTerm: [jp: string, groupName: string | undefined];
   deleteGroupRequest: [name: string];
   reorderGroups: [from: string, to: string];
+  syncRemoteToLocal: [];
+  syncLocalToEditing: [];
+  clearRequest: [];
 }>();
 
 const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
@@ -266,6 +270,31 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
         type="error"
         style="flex-shrink: 0; margin-left: 8px"
         @action="emit('deleteGroup')"
+      />
+
+      <!-- 单向同步 + 清空 -->
+      <c-button
+        label="远程→本地"
+        size="tiny"
+        text
+        style="flex-shrink: 0"
+        @action="emit('syncRemoteToLocal')"
+      />
+      <c-button
+        label="本地→编辑区"
+        size="tiny"
+        text
+        style="flex-shrink: 0"
+        @action="emit('syncLocalToEditing')"
+      />
+      <c-button
+        v-if="isAdmin"
+        label="清空"
+        size="tiny"
+        text
+        type="error"
+        style="flex-shrink: 0"
+        @action="emit('clearRequest')"
       />
     </div>
   </div>

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -38,6 +38,7 @@ const props = defineProps<{
   newGroupName: string;
   ungroupedCount: number;
   isAdmin: boolean;
+  historyCount: number;
 }>();
 
 const emit = defineEmits<{
@@ -59,6 +60,7 @@ const emit = defineEmits<{
   sortByTimeReverse: [];
   sortByKana: [];
   sortByKanaReverse: [];
+  showHistory: [];
 }>();
 
 const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
@@ -465,6 +467,15 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
         style="flex-shrink: 0"
         @action="emit('syncLocalToEditing')"
       />
+      <n-button
+        size="tiny"
+        text
+        style="flex-shrink: 0; font-size: 12px"
+        @click="emit('showHistory')"
+      >
+        历史
+        <span v-if="historyCount > 0">[{{ historyCount }}]</span>
+      </n-button>
       <c-button
         v-if="isAdmin"
         class="danger-hover-green"

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -49,7 +49,7 @@ const emit = defineEmits<{
   'update:newGroupName': [value: string];
   showNewGroup: [];
   deleteGroup: [];
-  dropTerm: [jp: string, groupName: string | undefined];
+  dropTerm: [jp: string | string[], groupName: string | undefined];
   deleteGroupRequest: [name: string];
   reorderGroups: [from: string, to: string];
   syncRemoteToLocal: [];
@@ -234,8 +234,19 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
     return;
   }
   draggedGroup.value = null;
-  const jp = e.dataTransfer?.getData('text/plain');
-  if (jp) emit('dropTerm', jp, groupName);
+  const raw = e.dataTransfer?.getData('text/plain');
+  if (!raw) {
+    dragOverGroup.value = undefined;
+    return;
+  }
+  let jps: string | string[] = raw;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) jps = parsed;
+  } catch {
+    /* not JSON, use raw string */
+  }
+  emit('dropTerm', jps, groupName);
   dragOverGroup.value = undefined;
 }
 </script>

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -23,6 +23,10 @@ const selectBorder = computed(() =>
   isDark.value ? '#76e2b6' : primaryColor.value,
 );
 const selectTextColor = computed(() => (isDark.value ? '#76e2b6' : undefined));
+const dragOverBg = computed(() =>
+  isDark.value ? 'rgba(34, 197, 94, 0.2)' : 'rgba(34, 197, 94, 0.1)',
+);
+const dragOverBorder = computed(() => (isDark.value ? '#4ade80' : '#22c55e'));
 
 const props = defineProps<{
   groupNames: string[];
@@ -75,19 +79,35 @@ function onTabWheel(e: WheelEvent) {
 }
 
 const dragOverGroup = ref<string | undefined>(undefined);
+const draggedGroup = ref<string | null>(null);
 
 function onDragStart(e: DragEvent, name: string) {
-  e.dataTransfer!.setData('application/x-group-name', name);
+  draggedGroup.value = name;
+  e.dataTransfer!.setData('text/plain', name);
   e.dataTransfer!.effectAllowed = 'move';
 }
 
+function onDragEnd() {
+  draggedGroup.value = null;
+}
+
+function onTabsDragLeave(e: DragEvent) {
+  const el = e.currentTarget as HTMLElement;
+  const related = e.relatedTarget as HTMLElement | null;
+  if (!related || !el.contains(related)) {
+    dragOverGroup.value = undefined;
+  }
+}
+
 function onDrop(e: DragEvent, groupName: string | undefined) {
-  const dragGroup = e.dataTransfer?.getData('application/x-group-name');
-  if (dragGroup && dragGroup !== groupName) {
-    emit('reorderGroups', dragGroup, groupName ?? '');
+  e.preventDefault();
+  if (draggedGroup.value && draggedGroup.value !== groupName) {
+    emit('reorderGroups', draggedGroup.value, groupName ?? '');
+    draggedGroup.value = null;
     dragOverGroup.value = undefined;
     return;
   }
+  draggedGroup.value = null;
   const jp = e.dataTransfer?.getData('text/plain');
   if (jp) emit('dropTerm', jp, groupName);
   dragOverGroup.value = undefined;
@@ -107,6 +127,7 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
   >
     <div
       style="display: flex; align-items: center; flex-wrap: nowrap; gap: 4px"
+      @dragleave="onTabsDragLeave"
     >
       <!-- 用户分组列表 -->
       <div
@@ -115,8 +136,8 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
         draggable="true"
         @click="emit('select', name)"
         @dragstart="(e: DragEvent) => onDragStart(e, name)"
+        @dragend="onDragEnd"
         @dragover.prevent="dragOverGroup = name"
-        @dragleave="dragOverGroup === name && (dragOverGroup = undefined)"
         @drop="(e: DragEvent) => onDrop(e, name)"
         @contextmenu.prevent="emit('deleteGroupRequest', name)"
         @touchstart="startLongPress(name)"
@@ -133,27 +154,21 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
             selectedGroup === name
               ? selectBg
               : dragOverGroup === name
-                ? 'var(--primary-color-suppl, #d0e0ff)'
+                ? dragOverBg
                 : 'var(--n-action-color, rgba(0,0,0,0.03))',
           borderLeft:
             selectedGroup === name
               ? `3px solid ${selectBorder}`
               : dragOverGroup === name
-                ? '1px dashed var(--primary-color, #999)'
+                ? `1px dashed ${dragOverBorder}`
                 : '3px solid transparent',
           color: selectedGroup === name ? selectTextColor : undefined,
           borderRight:
-            dragOverGroup === name
-              ? '1px dashed var(--primary-color, #999)'
-              : 'none',
+            dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
           borderTop:
-            dragOverGroup === name
-              ? '1px dashed var(--primary-color, #999)'
-              : 'none',
+            dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
           borderBottom:
-            dragOverGroup === name
-              ? '1px dashed var(--primary-color, #999)'
-              : 'none',
+            dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
         }"
       >
         <template v-if="editingGroupName === name">
@@ -189,7 +204,6 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
       <div
         @click="emit('select', undefined)"
         @dragover.prevent="dragOverGroup = '未分组'"
-        @dragleave="dragOverGroup === '未分组' && (dragOverGroup = undefined)"
         @drop="(e: DragEvent) => onDrop(e, undefined)"
         :style="{
           padding: '4px 8px',
@@ -202,26 +216,26 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
             selectedGroup === undefined
               ? selectBg
               : dragOverGroup === '未分组'
-                ? 'var(--primary-color-suppl, #d0e0ff)'
+                ? dragOverBg
                 : 'var(--n-action-color, rgba(0,0,0,0.03))',
           borderLeft:
             selectedGroup === undefined
               ? `3px solid ${selectBorder}`
               : dragOverGroup === '未分组'
-                ? '1px dashed var(--primary-color, #999)'
+                ? `1px dashed ${dragOverBorder}`
                 : '3px solid transparent',
           color: selectedGroup === undefined ? selectTextColor : undefined,
           borderRight:
             dragOverGroup === '未分组'
-              ? '1px dashed var(--primary-color, #999)'
+              ? `1px dashed ${dragOverBorder}`
               : 'none',
           borderTop:
             dragOverGroup === '未分组'
-              ? '1px dashed var(--primary-color, #999)'
+              ? `1px dashed ${dragOverBorder}`
               : 'none',
           borderBottom:
             dragOverGroup === '未分组'
-              ? '1px dashed var(--primary-color, #999)'
+              ? `1px dashed ${dragOverBorder}`
               : 'none',
         }"
       >
@@ -264,6 +278,7 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
       <!-- 删除当前组 -->
       <c-button
         v-if="selectedGroup && selectedGroup !== '未分组'"
+        class="danger-hover-green"
         label="删除此组"
         size="tiny"
         text
@@ -289,6 +304,7 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
       />
       <c-button
         v-if="isAdmin"
+        class="danger-hover-green"
         label="清空"
         size="tiny"
         text
@@ -303,5 +319,11 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
 <style scoped>
 .hide-scrollbar::-webkit-scrollbar {
   display: none;
+}
+:deep(.danger-hover-green:hover) {
+  --n-text-color: #18a058 !important;
+  --n-text-color-hover: #18a058 !important;
+  --n-text-color-pressed: #18a058 !important;
+  --n-text-color-focus: #18a058 !important;
 }
 </style>

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -1,5 +1,28 @@
 <script lang="ts" setup>
 import { AddOutlined } from '@vicons/material';
+import { useThemeVars } from 'naive-ui';
+
+const themeVars = useThemeVars();
+const isDark = computed(() => {
+  const c = themeVars.value.bodyColor;
+  if (!c) return false;
+  const r = parseInt(c.substring(1, 3), 16);
+  const g = parseInt(c.substring(3, 5), 16);
+  const b = parseInt(c.substring(5, 7), 16);
+  return (r + g + b) / 3 < 128;
+});
+
+const primaryColor = computed(() => themeVars.value.primaryColor ?? '#18a058');
+const primaryColorSuppl = computed(
+  () => themeVars.value.primaryColorSuppl ?? '#d0e0ff',
+);
+const selectBg = computed(() =>
+  isDark.value ? '#263633' : primaryColorSuppl.value,
+);
+const selectBorder = computed(() =>
+  isDark.value ? '#76e2b6' : primaryColor.value,
+);
+const selectTextColor = computed(() => (isDark.value ? '#76e2b6' : undefined));
 
 const props = defineProps<{
   groupNames: string[];
@@ -21,96 +44,235 @@ const emit = defineEmits<{
   'update:newGroupName': [value: string];
   showNewGroup: [];
   deleteGroup: [];
+  dropTerm: [jp: string, groupName: string | undefined];
+  deleteGroupRequest: [name: string];
+  reorderGroups: [from: string, to: string];
 }>();
+
+const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
+
+function startLongPress(name: string) {
+  longPressTimer.value = setTimeout(() => {
+    emit('deleteGroupRequest', name);
+  }, 600);
+}
+
+function cancelLongPress() {
+  if (longPressTimer.value) {
+    clearTimeout(longPressTimer.value);
+    longPressTimer.value = null;
+  }
+}
+
+function onTabWheel(e: WheelEvent) {
+  const el = e.currentTarget as HTMLElement;
+  el.scrollLeft += e.deltaY;
+  e.preventDefault();
+}
+
+const dragOverGroup = ref<string | undefined>(undefined);
+
+function onDragStart(e: DragEvent, name: string) {
+  e.dataTransfer!.setData('application/x-group-name', name);
+  e.dataTransfer!.effectAllowed = 'move';
+}
+
+function onDrop(e: DragEvent, groupName: string | undefined) {
+  const dragGroup = e.dataTransfer?.getData('application/x-group-name');
+  if (dragGroup && dragGroup !== groupName) {
+    emit('reorderGroups', dragGroup, groupName ?? '');
+    dragOverGroup.value = undefined;
+    return;
+  }
+  const jp = e.dataTransfer?.getData('text/plain');
+  if (jp) emit('dropTerm', jp, groupName);
+  dragOverGroup.value = undefined;
+}
 </script>
 
 <template>
-  <!-- 用户分组列表 -->
   <div
-    v-for="name in groupNames"
-    :key="name"
-    @click="emit('select', name)"
-    :style="{
-      padding: '4px 8px',
-      cursor: 'pointer',
-      borderRadius: '4px',
-      fontSize: '12px',
-      whiteSpace: 'nowrap',
-      background:
-        selectedGroup === name
-          ? 'var(--primary-color-hover, #eee)'
-          : 'transparent',
-    }"
+    style="
+      overflow-x: auto;
+      white-space: nowrap;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+    "
+    class="hide-scrollbar"
+    @wheel="onTabWheel"
   >
-    <template v-if="editingGroupName === name">
-      <n-input
-        :value="editingGroupNewName"
+    <div
+      style="display: flex; align-items: center; flex-wrap: nowrap; gap: 4px"
+    >
+      <!-- 用户分组列表 -->
+      <div
+        v-for="name in groupNames"
+        :key="name"
+        draggable="true"
+        @click="emit('select', name)"
+        @dragstart="(e: DragEvent) => onDragStart(e, name)"
+        @dragover.prevent="dragOverGroup = name"
+        @dragleave="dragOverGroup === name && (dragOverGroup = undefined)"
+        @drop="(e: DragEvent) => onDrop(e, name)"
+        @contextmenu.prevent="emit('deleteGroupRequest', name)"
+        @touchstart="startLongPress(name)"
+        @touchend="cancelLongPress"
+        @touchmove="cancelLongPress"
+        :style="{
+          padding: '4px 8px',
+          cursor: 'pointer',
+          borderRadius: '4px',
+          fontSize: '12px',
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+          background:
+            selectedGroup === name
+              ? selectBg
+              : dragOverGroup === name
+                ? 'var(--primary-color-suppl, #d0e0ff)'
+                : 'var(--n-action-color, rgba(0,0,0,0.03))',
+          borderLeft:
+            selectedGroup === name
+              ? `3px solid ${selectBorder}`
+              : dragOverGroup === name
+                ? '1px dashed var(--primary-color, #999)'
+                : '3px solid transparent',
+          color: selectedGroup === name ? selectTextColor : undefined,
+          borderRight:
+            dragOverGroup === name
+              ? '1px dashed var(--primary-color, #999)'
+              : 'none',
+          borderTop:
+            dragOverGroup === name
+              ? '1px dashed var(--primary-color, #999)'
+              : 'none',
+          borderBottom:
+            dragOverGroup === name
+              ? '1px dashed var(--primary-color, #999)'
+              : 'none',
+        }"
+      >
+        <template v-if="editingGroupName === name">
+          <n-input
+            :value="editingGroupNewName"
+            size="tiny"
+            @update:value="emit('update:editingGroupNewName', $event)"
+            @blur="emit('finishRename')"
+            @keydown.enter="emit('finishRename')"
+          />
+        </template>
+        <template v-else>
+          <div
+            style="
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+              flex-wrap: nowrap;
+              gap: 6px;
+            "
+          >
+            <n-text @dblclick="emit('startRename', name)" style="flex: 1">
+              {{ name }}
+            </n-text>
+            <n-text depth="3" style="font-size: 10px">
+              {{ displayData[name]?.length ?? 0 }}
+            </n-text>
+          </div>
+        </template>
+      </div>
+
+      <!-- 未分组 -->
+      <div
+        @click="emit('select', undefined)"
+        @dragover.prevent="dragOverGroup = '未分组'"
+        @dragleave="dragOverGroup === '未分组' && (dragOverGroup = undefined)"
+        @drop="(e: DragEvent) => onDrop(e, undefined)"
+        :style="{
+          padding: '4px 8px',
+          cursor: 'pointer',
+          borderRadius: '4px',
+          fontSize: '12px',
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+          background:
+            selectedGroup === undefined
+              ? selectBg
+              : dragOverGroup === '未分组'
+                ? 'var(--primary-color-suppl, #d0e0ff)'
+                : 'var(--n-action-color, rgba(0,0,0,0.03))',
+          borderLeft:
+            selectedGroup === undefined
+              ? `3px solid ${selectBorder}`
+              : dragOverGroup === '未分组'
+                ? '1px dashed var(--primary-color, #999)'
+                : '3px solid transparent',
+          color: selectedGroup === undefined ? selectTextColor : undefined,
+          borderRight:
+            dragOverGroup === '未分组'
+              ? '1px dashed var(--primary-color, #999)'
+              : 'none',
+          borderTop:
+            dragOverGroup === '未分组'
+              ? '1px dashed var(--primary-color, #999)'
+              : 'none',
+          borderBottom:
+            dragOverGroup === '未分组'
+              ? '1px dashed var(--primary-color, #999)'
+              : 'none',
+        }"
+      >
+        <div
+          style="
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: nowrap;
+            gap: 6px;
+          "
+        >
+          <n-text>未分组</n-text>
+          <n-text depth="3" style="font-size: 10px">
+            {{ ungroupedCount }}
+          </n-text>
+        </div>
+      </div>
+      <!-- 新建组 -->
+      <div v-if="showNewGroupInput" style="flex-shrink: 0">
+        <n-input
+          :value="newGroupName"
+          size="tiny"
+          placeholder="新分组名"
+          @update:value="emit('update:newGroupName', $event)"
+          @keydown.enter="emit('addNewGroup')"
+          @blur="emit('addNewGroup')"
+        />
+      </div>
+      <c-button
+        v-else
+        :icon="AddOutlined"
+        label="新建组"
         size="tiny"
-        @update:value="emit('update:editingGroupNewName', $event)"
-        @blur="emit('finishRename')"
-        @keydown.enter="emit('finishRename')"
+        text
+        style="flex-shrink: 0"
+        @action="emit('showNewGroup')"
       />
-    </template>
-    <template v-else>
-      <n-flex justify="space-between" align="center">
-        <n-text @dblclick="emit('startRename', name)" style="flex: 1">
-          {{ name }}
-        </n-text>
-        <n-text depth="3" style="font-size: 10px">
-          {{ displayData[name]?.length ?? 0 }}
-        </n-text>
-      </n-flex>
-    </template>
-  </div>
 
-  <!-- 未分组 -->
-  <div
-    @click="emit('select', undefined)"
-    :style="{
-      padding: '4px 8px',
-      cursor: 'pointer',
-      borderRadius: '4px',
-      fontSize: '12px',
-      whiteSpace: 'nowrap',
-      background:
-        selectedGroup === undefined
-          ? 'var(--primary-color-hover, #eee)'
-          : 'transparent',
-    }"
-  >
-    <n-flex justify="space-between" align="center">
-      <n-text>未分组</n-text>
-      <n-text depth="3" style="font-size: 10px">{{ ungroupedCount }}</n-text>
-    </n-flex>
+      <!-- 删除当前组 -->
+      <c-button
+        v-if="selectedGroup && selectedGroup !== '未分组'"
+        label="删除此组"
+        size="tiny"
+        text
+        type="error"
+        style="flex-shrink: 0; margin-left: 8px"
+        @action="emit('deleteGroup')"
+      />
+    </div>
   </div>
-
-  <!-- 新建组 -->
-  <div v-if="showNewGroupInput" style="margin-top: 4px">
-    <n-input
-      :value="newGroupName"
-      size="tiny"
-      placeholder="新分组名"
-      @update:value="emit('update:newGroupName', $event)"
-      @keydown.enter="emit('addNewGroup')"
-      @blur="emit('addNewGroup')"
-    />
-  </div>
-  <c-button
-    v-else
-    :icon="AddOutlined"
-    label="新建组"
-    size="tiny"
-    text
-    @action="emit('showNewGroup')"
-  />
-
-  <!-- 删除当前组 -->
-  <c-button
-    v-if="selectedGroup && selectedGroup !== '未分组'"
-    label="删除此组"
-    size="tiny"
-    text
-    type="error"
-    @action="emit('deleteGroup')"
-  />
 </template>
+
+<style scoped>
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -59,10 +59,87 @@ const emit = defineEmits<{
 
 const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
 
-function startLongPress(name: string) {
+const touchDrag = ref<{
+  active: boolean;
+  groupName: string | null;
+  startX: number;
+  startY: number;
+  isDragging: boolean;
+}>({ active: false, groupName: null, startX: 0, startY: 0, isDragging: false });
+
+function findGroupFromTouch(touch: Touch): string | undefined {
+  const el = document.elementFromPoint(touch.clientX, touch.clientY);
+  if (!el) return undefined;
+  const tab = (el as HTMLElement).closest('[data-group-name]');
+  return (tab as HTMLElement | null)?.dataset.groupName;
+}
+
+function onTouchStart(e: TouchEvent, name: string) {
   longPressTimer.value = setTimeout(() => {
     emit('deleteGroupRequest', name);
+    touchDrag.value = {
+      active: false,
+      groupName: null,
+      startX: 0,
+      startY: 0,
+      isDragging: false,
+    };
   }, 600);
+  const touch = e.touches[0];
+  touchDrag.value = {
+    active: true,
+    groupName: name,
+    startX: touch.clientX,
+    startY: touch.clientY,
+    isDragging: false,
+  };
+}
+
+function onTouchMove(e: TouchEvent) {
+  cancelLongPress();
+  if (!touchDrag.value.active) return;
+  const touch = e.touches[0];
+  const dx = Math.abs(touch.clientX - touchDrag.value.startX);
+  const dy = Math.abs(touch.clientY - touchDrag.value.startY);
+  if (!touchDrag.value.isDragging && (dx > 10 || dy > 10)) {
+    touchDrag.value.isDragging = true;
+  }
+  if (touchDrag.value.isDragging) {
+    e.preventDefault();
+    dragOverGroup.value = findGroupFromTouch(touch);
+  }
+}
+
+function onTouchEnd(e: TouchEvent) {
+  cancelLongPress();
+  if (!touchDrag.value.active) return;
+  if (touchDrag.value.isDragging) {
+    const touch = e.changedTouches[0];
+    let targetGroup = findGroupFromTouch(touch) ?? dragOverGroup.value;
+    if (targetGroup === '未分组') targetGroup = undefined;
+    if (targetGroup) {
+      targetGroup = resolveDropTarget(
+        touch.clientX,
+        touch.clientY,
+        targetGroup,
+      );
+    }
+    if (
+      touchDrag.value.groupName &&
+      targetGroup !== undefined &&
+      targetGroup !== touchDrag.value.groupName
+    ) {
+      emit('reorderGroups', touchDrag.value.groupName, targetGroup);
+    }
+    dragOverGroup.value = undefined;
+  }
+  touchDrag.value = {
+    active: false,
+    groupName: null,
+    startX: 0,
+    startY: 0,
+    isDragging: false,
+  };
 }
 
 function cancelLongPress() {
@@ -70,6 +147,26 @@ function cancelLongPress() {
     clearTimeout(longPressTimer.value);
     longPressTimer.value = null;
   }
+}
+
+function resolveDropTarget(
+  clientX: number,
+  clientY: number,
+  currentTarget: string,
+): string {
+  const el = document.elementFromPoint(clientX, clientY);
+  if (!el) return currentTarget;
+  const tab = (el as HTMLElement).closest(
+    '[data-group-name]',
+  ) as HTMLElement | null;
+  if (!tab || tab.dataset.groupName !== currentTarget) return currentTarget;
+  const rect = tab.getBoundingClientRect();
+  if (clientX <= rect.left + rect.width / 2) return currentTarget;
+  const idx = props.groupNames.indexOf(currentTarget);
+  if (idx >= 0 && idx < props.groupNames.length - 1) {
+    return props.groupNames[idx + 1];
+  }
+  return '';
 }
 
 function onTabWheel(e: WheelEvent) {
@@ -91,6 +188,13 @@ function onDragEnd() {
   draggedGroup.value = null;
 }
 
+function isDragTarget(name: string): boolean {
+  if (dragOverGroup.value !== name) return false;
+  if (draggedGroup.value === name) return false;
+  if (touchDrag.value.groupName === name) return false;
+  return true;
+}
+
 function onTabsDragLeave(e: DragEvent) {
   const el = e.currentTarget as HTMLElement;
   const related = e.relatedTarget as HTMLElement | null;
@@ -102,7 +206,11 @@ function onTabsDragLeave(e: DragEvent) {
 function onDrop(e: DragEvent, groupName: string | undefined) {
   e.preventDefault();
   if (draggedGroup.value && draggedGroup.value !== groupName) {
-    emit('reorderGroups', draggedGroup.value, groupName ?? '');
+    let target = groupName ?? '';
+    if (target) {
+      target = resolveDropTarget(e.clientX, e.clientY, target);
+    }
+    emit('reorderGroups', draggedGroup.value, target);
     draggedGroup.value = null;
     dragOverGroup.value = undefined;
     return;
@@ -128,84 +236,111 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
     <div
       style="display: flex; align-items: center; flex-wrap: nowrap; gap: 4px"
       @dragleave="onTabsDragLeave"
+      @dragover.prevent
+      @drop="
+        (e: DragEvent) => {
+          e.preventDefault();
+          onDrop(e, dragOverGroup === '未分组' ? undefined : dragOverGroup);
+        }
+      "
     >
       <!-- 用户分组列表 -->
-      <div
-        v-for="name in groupNames"
-        :key="name"
-        draggable="true"
-        @click="emit('select', name)"
-        @dragstart="(e: DragEvent) => onDragStart(e, name)"
-        @dragend="onDragEnd"
-        @dragover.prevent="dragOverGroup = name"
-        @drop="(e: DragEvent) => onDrop(e, name)"
-        @contextmenu.prevent="emit('deleteGroupRequest', name)"
-        @touchstart="startLongPress(name)"
-        @touchend="cancelLongPress"
-        @touchmove="cancelLongPress"
-        :style="{
-          padding: '4px 8px',
-          cursor: 'grab',
-          borderRadius: '4px',
-          fontSize: '12px',
-          whiteSpace: 'nowrap',
-          flexShrink: 0,
-          userSelect: 'none',
-          background:
-            selectedGroup === name
-              ? selectBg
-              : dragOverGroup === name
-                ? dragOverBg
-                : 'var(--n-action-color, rgba(0,0,0,0.03))',
-          borderLeft:
-            selectedGroup === name
-              ? `3px solid ${selectBorder}`
-              : dragOverGroup === name
-                ? `1px dashed ${dragOverBorder}`
-                : '3px solid transparent',
-          color: selectedGroup === name ? selectTextColor : undefined,
-          borderRight:
-            dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
-          borderTop:
-            dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
-          borderBottom:
-            dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
-        }"
+      <TransitionGroup
+        name="group-tab"
+        tag="div"
+        style="display: flex; gap: 4px"
       >
-        <template v-if="editingGroupName === name">
-          <n-input
-            :value="editingGroupNewName"
-            size="tiny"
-            @update:value="emit('update:editingGroupNewName', $event)"
-            @blur="emit('finishRename')"
-            @keydown.enter="emit('finishRename')"
-          />
-        </template>
-        <template v-else>
-          <div
-            style="
-              display: flex;
-              justify-content: space-between;
-              align-items: center;
-              flex-wrap: nowrap;
-              gap: 6px;
-            "
-          >
-            <n-text @dblclick="emit('startRename', name)" style="flex: 1">
-              {{ name }}
-            </n-text>
-            <n-text depth="3" style="font-size: 10px">
-              {{ displayData[name]?.length ?? 0 }}
-            </n-text>
-          </div>
-        </template>
-      </div>
+        <div
+          v-for="name in groupNames"
+          :key="name"
+          :data-group-name="name"
+          draggable="true"
+          @click="emit('select', name)"
+          @dragstart="(e: DragEvent) => onDragStart(e, name)"
+          @dragend="onDragEnd"
+          @dragover.prevent="dragOverGroup = name"
+          @drop="
+            (e: DragEvent) => {
+              e.stopPropagation();
+              onDrop(e, name);
+            }
+          "
+          @contextmenu.prevent="emit('deleteGroupRequest', name)"
+          @touchstart="(e: TouchEvent) => onTouchStart(e, name)"
+          @touchmove="(e: TouchEvent) => onTouchMove(e)"
+          @touchend="(e: TouchEvent) => onTouchEnd(e)"
+          :style="{
+            padding: '4px 8px',
+            cursor: 'grab',
+            borderRadius: '4px',
+            fontSize: '12px',
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+            userSelect: 'none',
+            touchAction: 'none',
+            background:
+              selectedGroup === name
+                ? selectBg
+                : dragOverGroup === name
+                  ? dragOverBg
+                  : 'var(--n-action-color, rgba(0,0,0,0.03))',
+            borderLeft:
+              selectedGroup === name
+                ? `3px solid ${selectBorder}`
+                : dragOverGroup === name
+                  ? `1px dashed ${dragOverBorder}`
+                  : '3px solid transparent',
+            color: selectedGroup === name ? selectTextColor : undefined,
+            borderRight:
+              dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
+            borderTop:
+              dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
+            borderBottom:
+              dragOverGroup === name ? `1px dashed ${dragOverBorder}` : 'none',
+            marginLeft: isDragTarget(name) ? '36px' : '0px',
+            transition: 'margin-left 0.2s ease, transform 0.25s ease',
+          }"
+        >
+          <template v-if="editingGroupName === name">
+            <n-input
+              :value="editingGroupNewName"
+              size="tiny"
+              @update:value="emit('update:editingGroupNewName', $event)"
+              @blur="emit('finishRename')"
+              @keydown.enter="emit('finishRename')"
+            />
+          </template>
+          <template v-else>
+            <div
+              style="
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                flex-wrap: nowrap;
+                gap: 6px;
+              "
+            >
+              <n-text @dblclick="emit('startRename', name)" style="flex: 1">
+                {{ name }}
+              </n-text>
+              <n-text depth="3" style="font-size: 10px">
+                {{ displayData[name]?.length ?? 0 }}
+              </n-text>
+            </div>
+          </template>
+        </div>
+      </TransitionGroup>
 
       <!-- 未分组 -->
       <div
         @click="emit('select', undefined)"
         @dragover.prevent="dragOverGroup = '未分组'"
-        @drop="(e: DragEvent) => onDrop(e, undefined)"
+        @drop="
+          (e: DragEvent) => {
+            e.stopPropagation();
+            onDrop(e, undefined);
+          }
+        "
         :style="{
           padding: '4px 8px',
           cursor: 'pointer',
@@ -238,6 +373,8 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
             dragOverGroup === '未分组'
               ? `1px dashed ${dragOverBorder}`
               : 'none',
+          marginLeft: dragOverGroup === '未分组' ? '36px' : '0px',
+          transition: 'margin-left 0.2s ease, transform 0.25s ease',
         }"
       >
         <div
@@ -320,6 +457,19 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
 <style scoped>
 .hide-scrollbar::-webkit-scrollbar {
   display: none;
+}
+.group-tab-move,
+.group-tab-enter-active,
+.group-tab-leave-active {
+  transition: transform 0.25s ease;
+}
+.group-tab-enter-from,
+.group-tab-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
+.group-tab-leave-active {
+  position: absolute;
 }
 :deep(.danger-hover-green:hover) {
   --n-text-color: #18a058 !important;

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -145,11 +145,12 @@ function onDrop(e: DragEvent, groupName: string | undefined) {
         @touchmove="cancelLongPress"
         :style="{
           padding: '4px 8px',
-          cursor: 'pointer',
+          cursor: 'grab',
           borderRadius: '4px',
           fontSize: '12px',
           whiteSpace: 'nowrap',
           flexShrink: 0,
+          userSelect: 'none',
           background:
             selectedGroup === name
               ? selectBg

--- a/web/src/components/GlossaryGroupTabs.vue
+++ b/web/src/components/GlossaryGroupTabs.vue
@@ -223,30 +223,30 @@ function onTabsDragLeave(e: DragEvent) {
 
 function onDrop(e: DragEvent, groupName: string | undefined) {
   e.preventDefault();
+  // 有 term 数据 → 优先走 term drop 逻辑
+  const raw = e.dataTransfer?.getData('text/plain');
+  if (raw) {
+    let jps: string | string[] = raw;
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) jps = parsed;
+    } catch {
+      /* not JSON, use raw string */
+    }
+    emit('dropTerm', jps, groupName);
+    draggedGroup.value = null;
+    dragOverGroup.value = undefined;
+    return;
+  }
+  // 无 term 数据 → tab reorder
   if (draggedGroup.value && draggedGroup.value !== groupName) {
     let target = groupName ?? '';
     if (target) {
       target = resolveDropTarget(e.clientX, e.clientY, target);
     }
     emit('reorderGroups', draggedGroup.value, target);
-    draggedGroup.value = null;
-    dragOverGroup.value = undefined;
-    return;
   }
   draggedGroup.value = null;
-  const raw = e.dataTransfer?.getData('text/plain');
-  if (!raw) {
-    dragOverGroup.value = undefined;
-    return;
-  }
-  let jps: string | string[] = raw;
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) jps = parsed;
-  } catch {
-    /* not JSON, use raw string */
-  }
-  emit('dropTerm', jps, groupName);
   dragOverGroup.value = undefined;
 }
 </script>

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -1,0 +1,135 @@
+<script lang="ts" setup>
+import { DeleteOutlineOutlined } from '@vicons/material';
+import type { GlossaryEntry } from '@/model/GlossaryGroup';
+
+defineProps<{
+  entries: GlossaryEntry[];
+  glossary: Record<string, string>;
+  selectedTerms: Set<string>;
+  isInServerGlossary: (jp: string) => boolean;
+  isZhConflict: (jp: string) => boolean;
+  getLocalZh: (jp: string) => string | undefined;
+  novelId: string;
+  inGroup: boolean;
+}>();
+
+const emit = defineEmits<{
+  toggleSelect: [jp: string, event: MouseEvent];
+  deleteTerm: [jp: string];
+  moveToGroup: [jp: string];
+  removeFromGroup: [jp: string];
+  revertTerm: [jp: string];
+  revertToLocalZh: [jp: string];
+  clearLocalRecord: [jp: string];
+}>();
+</script>
+
+<template>
+  <n-table striped size="small" style="font-size: 12px; max-width: 500px">
+    <tr
+      v-for="entry in entries"
+      :key="entry.jp"
+      :style="{
+        background: selectedTerms.has(entry.jp)
+          ? 'var(--primary-color-suppl, #d0e0ff)'
+          : undefined,
+      }"
+      @click="emit('toggleSelect', entry.jp, $event)"
+    >
+      <!-- 删除按钮 -->
+      <td style="width: 32px">
+        <c-button
+          v-if="isInServerGlossary(entry.jp)"
+          :icon="DeleteOutlineOutlined"
+          text
+          type="error"
+          size="small"
+          @action="emit('deleteTerm', entry.jp)"
+        />
+      </td>
+
+      <!-- jp -->
+      <td>
+        <n-text
+          :depth="isInServerGlossary(entry.jp) ? undefined : 3"
+          :style="
+            isInServerGlossary(entry.jp)
+              ? {}
+              : { textDecoration: 'line-through' }
+          "
+        >
+          {{ entry.jp }}
+        </n-text>
+      </td>
+
+      <td nowrap="nowrap">=></td>
+
+      <!-- zh -->
+      <td style="padding-right: 8px">
+        <template v-if="isInServerGlossary(entry.jp)">
+          <n-input
+            v-model:value="glossary[entry.jp]"
+            size="tiny"
+            placeholder="请输入中文翻译"
+            :theme-overrides="{ border: '0', color: 'transprent' }"
+          />
+        </template>
+        <n-text v-else depth="3" style="text-decoration: line-through">
+          {{ entry.zh }}
+        </n-text>
+      </td>
+
+      <!-- 操作按钮 -->
+      <td style="white-space: nowrap">
+        <!-- 不在服务端 → 回退按钮 -->
+        <c-button
+          v-if="!isInServerGlossary(entry.jp) && novelId"
+          label="回退"
+          size="tiny"
+          text
+          type="info"
+          @action="emit('revertTerm', entry.jp)"
+        />
+
+        <!-- 在分组中 → 移出按钮 -->
+        <c-button
+          v-if="isInServerGlossary(entry.jp) && inGroup"
+          label="移出"
+          size="tiny"
+          text
+          @action="emit('removeFromGroup', entry.jp)"
+        />
+
+        <!-- 在未分组且当前有选中分组 → 移入按钮 -->
+        <c-button
+          v-if="isInServerGlossary(entry.jp) && !inGroup && novelId"
+          label="移入"
+          size="tiny"
+          text
+          type="info"
+          @action="emit('moveToGroup', entry.jp)"
+        />
+
+        <!-- zh 冲突提示 -->
+        <template v-if="isInServerGlossary(entry.jp) && isZhConflict(entry.jp)">
+          <n-text depth="3" style="font-size: 10px; margin-left: 4px">
+            本地：{{ getLocalZh(entry.jp) }}
+          </n-text>
+          <c-button
+            label="回退到本地"
+            size="tiny"
+            text
+            @action="emit('revertToLocalZh', entry.jp)"
+          />
+          <c-button
+            label="清除本地"
+            size="tiny"
+            text
+            type="error"
+            @action="emit('clearLocalRecord', entry.jp)"
+          />
+        </template>
+      </td>
+    </tr>
+  </n-table>
+</template>

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -16,7 +16,6 @@ defineProps<{
 const emit = defineEmits<{
   toggleSelect: [jp: string, event: MouseEvent];
   deleteTerm: [jp: string];
-  moveToGroup: [jp: string];
   removeFromGroup: [jp: string];
   revertTerm: [jp: string];
   revertToLocalZh: [jp: string];
@@ -29,23 +28,50 @@ const emit = defineEmits<{
     <tr
       v-for="entry in entries"
       :key="entry.jp"
+      draggable="true"
       :style="{
         background: selectedTerms.has(entry.jp)
           ? 'var(--primary-color-suppl, #d0e0ff)'
           : undefined,
       }"
       @click="emit('toggleSelect', entry.jp, $event)"
+      @dragstart="
+        (e: DragEvent) => {
+          e.dataTransfer!.setData('text/plain', entry.jp);
+          (e.target as HTMLElement).style.opacity = '0.5';
+        }
+      "
+      @dragend="
+        (e: DragEvent) => {
+          (e.target as HTMLElement).style.opacity = '';
+        }
+      "
     >
       <!-- 删除按钮 -->
       <td style="width: 32px">
-        <c-button
-          v-if="isInServerGlossary(entry.jp)"
-          :icon="DeleteOutlineOutlined"
-          text
-          type="error"
-          size="small"
-          @action="emit('deleteTerm', entry.jp)"
-        />
+        <span style="position: relative; top: 2px">
+          <c-button
+            v-if="isInServerGlossary(entry.jp)"
+            :icon="DeleteOutlineOutlined"
+            text
+            type="error"
+            size="small"
+            @action="emit('deleteTerm', entry.jp)"
+          />
+        </span>
+      </td>
+
+      <!-- 拖拽把手 -->
+      <td
+        style="
+          width: 20px;
+          cursor: grab;
+          color: var(--n-text-color-disabled, #999);
+          font-size: 10px;
+          padding: 0 2px;
+        "
+      >
+        <span style="position: relative; top: -2px">:::</span>
       </td>
 
       <!-- jp -->
@@ -98,16 +124,6 @@ const emit = defineEmits<{
           size="tiny"
           text
           @action="emit('removeFromGroup', entry.jp)"
-        />
-
-        <!-- 在未分组且当前有选中分组 → 移入按钮 -->
-        <c-button
-          v-if="isInServerGlossary(entry.jp) && !inGroup && novelId"
-          label="移入"
-          size="tiny"
-          text
-          type="info"
-          @action="emit('moveToGroup', entry.jp)"
         />
 
         <!-- zh 冲突提示 -->

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -41,6 +41,7 @@ const props = defineProps<{
   novelId: string;
   inGroup: boolean;
   groupName?: string;
+  deletedJps: Set<string>;
 }>();
 
 const emit = defineEmits<{
@@ -169,6 +170,7 @@ function onRowDrop(e: DragEvent) {
               placeholder="请输入中文翻译"
               :theme-overrides="{ border: '0', color: 'transparent' }"
               @click.stop
+              @keydown.enter="($event.target as HTMLInputElement).blur()"
             />
           </template>
           <n-text v-else depth="3" style="text-decoration: line-through">
@@ -178,9 +180,13 @@ function onRowDrop(e: DragEvent) {
 
         <!-- 操作按钮 -->
         <td style="white-space: nowrap">
-          <!-- 不在服务端 → 回退按钮 -->
+          <!-- 不在服务端且未主动删除 → 回退按钮 -->
           <c-button
-            v-if="!isInServerGlossary(entry.jp) && novelId"
+            v-if="
+              !isInServerGlossary(entry.jp) &&
+              novelId &&
+              !deletedJps.has(entry.jp)
+            "
             label="回退"
             size="tiny"
             text

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -2,7 +2,7 @@
 import { DeleteOutlineOutlined } from '@vicons/material';
 import type { GlossaryEntry } from '@/model/GlossaryGroup';
 
-defineProps<{
+const props = defineProps<{
   entries: GlossaryEntry[];
   glossary: Record<string, string>;
   selectedTerms: Set<string>;
@@ -11,6 +11,7 @@ defineProps<{
   getLocalZh: (jp: string) => string | undefined;
   novelId: string;
   inGroup: boolean;
+  groupName?: string;
 }>();
 
 const emit = defineEmits<{
@@ -20,132 +21,195 @@ const emit = defineEmits<{
   revertTerm: [jp: string];
   revertToLocalZh: [jp: string];
   clearLocalRecord: [jp: string];
+  reorderTerm: [fromIndex: number, toIndex: number];
 }>();
+
+const dragFromIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
+
+function onRowDragStart(e: DragEvent, entry: GlossaryEntry, index: number) {
+  dragFromIndex.value = index;
+  e.dataTransfer!.setData('text/plain', entry.jp);
+  e.dataTransfer!.effectAllowed = 'move';
+  (e.target as HTMLElement).style.opacity = '0.5';
+}
+
+function onRowDragEnd(e: DragEvent) {
+  dragFromIndex.value = null;
+  dragOverIndex.value = null;
+  (e.target as HTMLElement).style.opacity = '';
+}
+
+function onRowDragOver(e: DragEvent, index: number) {
+  if (dragFromIndex.value === null) return;
+  e.preventDefault();
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  const midY = rect.top + rect.height / 2;
+  dragOverIndex.value = e.clientY < midY ? index : index + 1;
+}
+
+function onRowDrop(e: DragEvent) {
+  e.preventDefault();
+  const from = dragFromIndex.value;
+  const to = dragOverIndex.value;
+  dragFromIndex.value = null;
+  dragOverIndex.value = null;
+  if (from === null || to === null || from === to) return;
+  emit('reorderTerm', from, to);
+}
 </script>
 
 <template>
-  <n-table striped size="small" style="font-size: 12px; max-width: 500px">
-    <tr
-      v-for="entry in entries"
-      :key="entry.jp"
-      draggable="true"
-      :style="{
-        background: selectedTerms.has(entry.jp)
-          ? 'var(--primary-color-suppl, #d0e0ff)'
-          : undefined,
-      }"
-      @click="emit('toggleSelect', entry.jp, $event)"
-      @dragstart="
-        (e: DragEvent) => {
-          e.dataTransfer!.setData('text/plain', entry.jp);
-          (e.target as HTMLElement).style.opacity = '0.5';
-        }
-      "
-      @dragend="
-        (e: DragEvent) => {
-          (e.target as HTMLElement).style.opacity = '';
-        }
-      "
-    >
-      <!-- 删除按钮 -->
-      <td style="width: 32px">
-        <span style="position: relative; top: 2px">
-          <c-button
-            v-if="isInServerGlossary(entry.jp)"
-            :icon="DeleteOutlineOutlined"
-            text
-            type="error"
-            size="small"
-            @action="emit('deleteTerm', entry.jp)"
-          />
-        </span>
-      </td>
-
-      <!-- 拖拽把手 -->
-      <td
-        style="
-          width: 20px;
-          cursor: grab;
-          color: var(--n-text-color-disabled, #999);
-          font-size: 10px;
-          padding: 0 2px;
-        "
+  <table class="term-table">
+    <TransitionGroup name="term-row" tag="tbody">
+      <tr
+        v-for="(entry, index) in entries"
+        :key="entry.jp"
+        draggable="true"
+        :style="{
+          background: selectedTerms.has(entry.jp)
+            ? 'var(--primary-color-suppl, #d0e0ff)'
+            : undefined,
+          borderTop:
+            dragOverIndex === index && dragFromIndex !== index
+              ? '2px solid var(--primary-color, #18a058)'
+              : undefined,
+        }"
+        @click="emit('toggleSelect', entry.jp, $event)"
+        @dragstart="(e: DragEvent) => onRowDragStart(e, entry, index)"
+        @dragend="(e: DragEvent) => onRowDragEnd(e)"
+        @dragover="(e: DragEvent) => onRowDragOver(e, index)"
+        @drop="(e: DragEvent) => onRowDrop(e)"
       >
-        <span style="position: relative; top: -2px">:::</span>
-      </td>
+        <!-- 删除按钮 -->
+        <td style="width: 32px">
+          <span style="position: relative; top: 2px">
+            <c-button
+              v-if="isInServerGlossary(entry.jp)"
+              :icon="DeleteOutlineOutlined"
+              text
+              type="error"
+              size="small"
+              @action="emit('deleteTerm', entry.jp)"
+            />
+          </span>
+        </td>
 
-      <!-- jp -->
-      <td>
-        <n-text
-          :depth="isInServerGlossary(entry.jp) ? undefined : 3"
-          :style="
-            isInServerGlossary(entry.jp)
-              ? {}
-              : { textDecoration: 'line-through' }
+        <!-- 拖拽把手 -->
+        <td
+          style="
+            width: 20px;
+            cursor: grab;
+            color: var(--n-text-color-disabled, #999);
+            font-size: 10px;
+            padding: 0 2px;
           "
         >
-          {{ entry.jp }}
-        </n-text>
-      </td>
+          <span style="position: relative; top: -2px">:::</span>
+        </td>
 
-      <td nowrap="nowrap">=></td>
-
-      <!-- zh -->
-      <td style="padding-right: 8px">
-        <template v-if="isInServerGlossary(entry.jp)">
-          <n-input
-            v-model:value="glossary[entry.jp]"
-            size="tiny"
-            placeholder="请输入中文翻译"
-            :theme-overrides="{ border: '0', color: 'transprent' }"
-          />
-        </template>
-        <n-text v-else depth="3" style="text-decoration: line-through">
-          {{ entry.zh }}
-        </n-text>
-      </td>
-
-      <!-- 操作按钮 -->
-      <td style="white-space: nowrap">
-        <!-- 不在服务端 → 回退按钮 -->
-        <c-button
-          v-if="!isInServerGlossary(entry.jp) && novelId"
-          label="回退"
-          size="tiny"
-          text
-          type="info"
-          @action="emit('revertTerm', entry.jp)"
-        />
-
-        <!-- 在分组中 → 移出按钮 -->
-        <c-button
-          v-if="isInServerGlossary(entry.jp) && inGroup"
-          label="移出"
-          size="tiny"
-          text
-          @action="emit('removeFromGroup', entry.jp)"
-        />
-
-        <!-- zh 冲突提示 -->
-        <template v-if="isInServerGlossary(entry.jp) && isZhConflict(entry.jp)">
-          <n-text depth="3" style="font-size: 10px; margin-left: 4px">
-            本地：{{ getLocalZh(entry.jp) }}
+        <!-- jp -->
+        <td>
+          <n-text
+            :depth="isInServerGlossary(entry.jp) ? undefined : 3"
+            :style="
+              isInServerGlossary(entry.jp)
+                ? {}
+                : { textDecoration: 'line-through' }
+            "
+          >
+            {{ entry.jp }}
           </n-text>
+        </td>
+
+        <td nowrap="nowrap">=></td>
+
+        <!-- zh -->
+        <td style="padding-right: 8px">
+          <template v-if="isInServerGlossary(entry.jp)">
+            <n-input
+              v-model:value="glossary[entry.jp]"
+              size="tiny"
+              placeholder="请输入中文翻译"
+              :theme-overrides="{ border: '0', color: 'transprent' }"
+            />
+          </template>
+          <n-text v-else depth="3" style="text-decoration: line-through">
+            {{ entry.zh }}
+          </n-text>
+        </td>
+
+        <!-- 操作按钮 -->
+        <td style="white-space: nowrap">
+          <!-- 不在服务端 → 回退按钮 -->
           <c-button
-            label="回退到本地"
+            v-if="!isInServerGlossary(entry.jp) && novelId"
+            label="回退"
             size="tiny"
             text
-            @action="emit('revertToLocalZh', entry.jp)"
+            type="info"
+            @action="emit('revertTerm', entry.jp)"
           />
+
+          <!-- 在分组中 → 移出按钮 -->
           <c-button
-            label="清除本地"
+            v-if="isInServerGlossary(entry.jp) && inGroup"
+            label="移出"
             size="tiny"
             text
-            type="error"
-            @action="emit('clearLocalRecord', entry.jp)"
+            @action="emit('removeFromGroup', entry.jp)"
           />
-        </template>
-      </td>
-    </tr>
-  </n-table>
+
+          <!-- zh 冲突提示 -->
+          <template
+            v-if="isInServerGlossary(entry.jp) && isZhConflict(entry.jp)"
+          >
+            <n-text depth="3" style="font-size: 10px; margin-left: 4px">
+              本地：{{ getLocalZh(entry.jp) }}
+            </n-text>
+            <c-button
+              label="回退到本地"
+              size="tiny"
+              text
+              @action="emit('revertToLocalZh', entry.jp)"
+            />
+            <c-button
+              label="清除本地"
+              size="tiny"
+              text
+              type="error"
+              @action="emit('clearLocalRecord', entry.jp)"
+            />
+          </template>
+        </td>
+      </tr>
+    </TransitionGroup>
+  </table>
 </template>
+
+<style scoped>
+.term-table {
+  width: 100%;
+  max-width: 500px;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.term-table tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.term-row-move {
+  transition: transform 0.25s ease;
+}
+
+.term-row-enter-active,
+.term-row-leave-active {
+  transition: all 0.25s ease;
+}
+
+.term-row-enter-from,
+.term-row-leave-to {
+  opacity: 0;
+}
+</style>

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -58,7 +58,11 @@ const dragOverIndex = ref<number | null>(null);
 
 function onRowDragStart(e: DragEvent, entry: GlossaryEntry, index: number) {
   dragFromIndex.value = index;
-  e.dataTransfer!.setData('text/plain', entry.jp);
+  const data =
+    selectedTerms.has(entry.jp) && selectedTerms.size > 1
+      ? JSON.stringify([...selectedTerms])
+      : entry.jp;
+  e.dataTransfer!.setData('text/plain', data);
   e.dataTransfer!.effectAllowed = 'move';
   (e.target as HTMLElement).style.opacity = '0.5';
 }

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -226,6 +226,7 @@ function onRowDrop(e: DragEvent) {
 
 .term-table td {
   padding: 6px 12px;
+  background: inherit;
 }
 
 .term-table tr {
@@ -236,13 +237,24 @@ function onRowDrop(e: DragEvent) {
   background: var(--term-stripe);
 }
 
+/* n-input 内部所有层都透出 tr 背景 */
+.term-table :deep(.n-input) {
+  --n-color: transparent;
+  background-color: transparent !important;
+}
+
+.term-table :deep(.n-input .n-input__border),
+.term-table :deep(.n-input .n-input__state-border) {
+  border: none !important;
+}
+
 .term-row-move {
   transition: transform 0.25s ease;
 }
 
 .term-row-enter-active,
 .term-row-leave-active {
-  transition: all 0.25s ease;
+  transition: opacity 0.25s ease;
 }
 
 .term-row-enter-from,

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -51,10 +51,13 @@ function onRowDragOver(e: DragEvent, index: number) {
 function onRowDrop(e: DragEvent) {
   e.preventDefault();
   const from = dragFromIndex.value;
-  const to = dragOverIndex.value;
+  let to = dragOverIndex.value;
   dragFromIndex.value = null;
   dragOverIndex.value = null;
   if (from === null || to === null || from === to) return;
+  // 向下拖时，splice 先移除 from 会导致 to 位置左移一位
+  if (from < to) to--;
+  if (from === to) return;
   emit('reorderTerm', from, to);
 }
 </script>

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -172,6 +172,7 @@ function onRowDrop(e: DragEvent) {
               size="tiny"
               placeholder="请输入中文翻译"
               :theme-overrides="{ border: '0', color: 'transparent' }"
+              @click.stop
             />
           </template>
           <n-text v-else depth="3" style="text-decoration: line-through">

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -58,11 +58,7 @@ const dragOverIndex = ref<number | null>(null);
 
 function onRowDragStart(e: DragEvent, entry: GlossaryEntry, index: number) {
   dragFromIndex.value = index;
-  const data =
-    selectedTerms.has(entry.jp) && selectedTerms.size > 1
-      ? JSON.stringify([...selectedTerms])
-      : entry.jp;
-  e.dataTransfer!.setData('text/plain', data);
+  e.dataTransfer!.setData('text/plain', entry.jp);
   e.dataTransfer!.effectAllowed = 'move';
   (e.target as HTMLElement).style.opacity = '0.5';
 }

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -195,8 +195,16 @@ function onRowDrop(e: DragEvent) {
   font-size: 12px;
 }
 
-.term-table tr:nth-child(even) {
-  background: rgba(0, 0, 0, 0.02);
+.term-table td {
+  padding: 6px 12px;
+}
+
+.term-table tr {
+  border-bottom: 1px solid var(--n-border-color, #efeff5);
+}
+
+.term-table tbody tr:nth-child(even) {
+  background: var(--n-td-striped-color, rgba(0, 0, 0, 0.04));
 }
 
 .term-row-move {

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -22,6 +22,15 @@ const termBorderColor = computed(() =>
   isDark.value ? 'rgba(255,255,255,0.08)' : '#efeff5',
 );
 
+const selectColor = computed(
+  () =>
+    themeVars.value.primaryColorSuppl ?? (isDark.value ? '#263633' : '#d0e0ff'),
+);
+
+const dragIndicatorColor = computed(
+  () => themeVars.value.primaryColor ?? '#18a058',
+);
+
 const props = defineProps<{
   entries: GlossaryEntry[];
   glossary: Record<string, string>;
@@ -96,12 +105,10 @@ function onRowDrop(e: DragEvent) {
         :key="entry.jp"
         draggable="true"
         :style="{
-          background: selectedTerms.has(entry.jp)
-            ? 'var(--primary-color-suppl, #d0e0ff)'
-            : undefined,
+          background: selectedTerms.has(entry.jp) ? selectColor : undefined,
           borderTop:
             dragOverIndex === index && dragFromIndex !== index
-              ? '2px solid var(--primary-color, #18a058)'
+              ? `2px solid ${dragIndicatorColor}`
               : undefined,
         }"
         @click="emit('toggleSelect', entry.jp, $event)"

--- a/web/src/components/GlossaryTermTable.vue
+++ b/web/src/components/GlossaryTermTable.vue
@@ -1,6 +1,26 @@
 <script lang="ts" setup>
 import { DeleteOutlineOutlined } from '@vicons/material';
+import { useThemeVars } from 'naive-ui';
 import type { GlossaryEntry } from '@/model/GlossaryGroup';
+
+const themeVars = useThemeVars();
+
+const isDark = computed(() => {
+  const c = themeVars.value.bodyColor;
+  if (!c) return false;
+  const r = parseInt(c.substring(1, 3), 16);
+  const g = parseInt(c.substring(3, 5), 16);
+  const b = parseInt(c.substring(5, 7), 16);
+  return (r + g + b) / 3 < 128;
+});
+
+const stripeColor = computed(() =>
+  isDark.value ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)',
+);
+
+const termBorderColor = computed(() =>
+  isDark.value ? 'rgba(255,255,255,0.08)' : '#efeff5',
+);
 
 const props = defineProps<{
   entries: GlossaryEntry[];
@@ -63,7 +83,13 @@ function onRowDrop(e: DragEvent) {
 </script>
 
 <template>
-  <table class="term-table">
+  <table
+    class="term-table"
+    :style="{
+      '--term-stripe': stripeColor,
+      '--term-border': termBorderColor,
+    }"
+  >
     <TransitionGroup name="term-row" tag="tbody">
       <tr
         v-for="(entry, index) in entries"
@@ -134,7 +160,7 @@ function onRowDrop(e: DragEvent) {
               v-model:value="glossary[entry.jp]"
               size="tiny"
               placeholder="请输入中文翻译"
-              :theme-overrides="{ border: '0', color: 'transprent' }"
+              :theme-overrides="{ border: '0', color: 'transparent' }"
             />
           </template>
           <n-text v-else depth="3" style="text-decoration: line-through">
@@ -203,11 +229,11 @@ function onRowDrop(e: DragEvent) {
 }
 
 .term-table tr {
-  border-bottom: 1px solid var(--n-border-color, #efeff5);
+  border-bottom: 1px solid var(--term-border);
 }
 
 .term-table tbody tr:nth-child(even) {
-  background: var(--n-td-striped-color, rgba(0, 0, 0, 0.04));
+  background: var(--term-stripe);
 }
 
 .term-row-move {

--- a/web/src/model/Glossary.ts
+++ b/web/src/model/Glossary.ts
@@ -39,7 +39,9 @@ export namespace Glossary {
       if (parts.length !== 2) return;
 
       const [jp, zh] = parts;
-      glossary[jp.trim()] = zh.trim();
+      const jpTrimmed = jp.trim();
+      if (!jpTrimmed) continue;
+      glossary[jpTrimmed] = zh.trim();
     }
     return glossary;
   };

--- a/web/src/model/GlossaryGroup.ts
+++ b/web/src/model/GlossaryGroup.ts
@@ -196,6 +196,44 @@ export namespace GlossaryGroup {
     saveGroups(novelId, groups);
   }
 
+  /** 按云端术语表 key 顺序排序（云端术语在前，本地术语在末尾保持原序） */
+  export function sortGroupByTime(
+    novelId: string,
+    groupName: string,
+    serverGlossary: Record<string, string>,
+    reverse: boolean,
+  ): void {
+    const groups = getGroups(novelId);
+    const entries = groups[groupName];
+    if (!entries || entries.length <= 1) return;
+    const cloudOrder = Object.keys(serverGlossary);
+    const cloudSet = new Set(cloudOrder);
+    const cloudTerms = entries.filter((e) => cloudSet.has(e.jp));
+    const localTerms = entries.filter((e) => !cloudSet.has(e.jp));
+    cloudTerms.sort(
+      (a, b) => cloudOrder.indexOf(a.jp) - cloudOrder.indexOf(b.jp),
+    );
+    const sorted = [...cloudTerms, ...localTerms];
+    if (reverse) sorted.reverse();
+    groups[groupName] = sorted;
+    saveGroups(novelId, groups);
+  }
+
+  /** 按 JP 五十音排序 */
+  export function sortGroupByKana(
+    novelId: string,
+    groupName: string,
+    reverse: boolean,
+  ): void {
+    const groups = getGroups(novelId);
+    const entries = groups[groupName];
+    if (!entries || entries.length <= 1) return;
+    const sorted = [...entries].sort((a, b) => a.jp.localeCompare(b.jp, 'ja'));
+    if (reverse) sorted.reverse();
+    groups[groupName] = sorted;
+    saveGroups(novelId, groups);
+  }
+
   /** 交叉比对：返回增补后的显示数据 */
   export function buildDisplayData(
     groups: GlossaryGroupMap,

--- a/web/src/model/GlossaryGroup.ts
+++ b/web/src/model/GlossaryGroup.ts
@@ -53,8 +53,10 @@ export namespace GlossaryGroup {
     order?: string[],
   ): boolean {
     const newOrder =
-      order ?? readStoredOrder(novelId).filter((k) => k in groups);
+      order ??
+      readStoredOrder(novelId).filter((k) => k in groups && k !== '未分组');
     for (const key of Object.keys(groups)) {
+      if (key === '未分组') continue;
       if (!newOrder.includes(key)) newOrder.push(key);
     }
     const data = { [ORDER_KEY]: newOrder, ...groups };
@@ -70,6 +72,37 @@ export namespace GlossaryGroup {
       console.warn('localStorage 写入失败，可能已满', e);
       return false;
     }
+  }
+
+  export function addToUngrouped(
+    novelId: string,
+    jp: string,
+    zh: string,
+  ): void {
+    const groups = getGroups(novelId);
+    if (!groups['未分组']) groups['未分组'] = [];
+    groups['未分组'].push({ jp, zh });
+    saveGroups(novelId, groups);
+  }
+
+  export function syncUngrouped(
+    novelId: string,
+    serverGlossary: Record<string, string>,
+  ): void {
+    const groups = getGroups(novelId);
+    const groupedJps = new Set<string>();
+    for (const name of Object.keys(groups)) {
+      if (name === '未分组') continue;
+      for (const e of groups[name] || []) groupedJps.add(e.jp);
+    }
+    if (!groups['未分组']) groups['未分组'] = [];
+    const seen = new Set(groups['未分组'].map((e) => e.jp));
+    for (const jp of Object.keys(serverGlossary)) {
+      if (!groupedJps.has(jp) && !seen.has(jp)) {
+        groups['未分组'].push({ jp, zh: serverGlossary[jp] });
+      }
+    }
+    saveGroups(novelId, groups);
   }
 
   export function clearGroups(novelId: string): void {
@@ -148,6 +181,21 @@ export namespace GlossaryGroup {
     return true;
   }
 
+  /** 组内术语重排 */
+  export function reorderTerm(
+    novelId: string,
+    groupName: string,
+    fromIndex: number,
+    toIndex: number,
+  ): void {
+    const groups = getGroups(novelId);
+    const entries = groups[groupName];
+    if (!entries || fromIndex < 0 || fromIndex >= entries.length) return;
+    const [item] = entries.splice(fromIndex, 1);
+    entries.splice(toIndex, 0, item);
+    saveGroups(novelId, groups);
+  }
+
   /** 交叉比对：返回增补后的显示数据 */
   export function buildDisplayData(
     groups: GlossaryGroupMap,
@@ -159,6 +207,7 @@ export namespace GlossaryGroup {
 
     const names = order ?? Object.keys(groups);
     for (const name of names) {
+      if (name === '未分组') continue;
       const entries = groups[name];
       if (!entries) continue;
       result[name] = entries.map((e) => {
@@ -170,10 +219,21 @@ export namespace GlossaryGroup {
       });
     }
 
-    // 未分组术语（在服务端但不在任何分组中）
+    // 未分组术语：优先使用存储的顺序，合并新增的服务端术语
+    const storedUngrouped = groups['未分组'] || [];
     const ungrouped: GlossaryEntry[] = [];
+    const seen = new Set<string>();
+    for (const e of storedUngrouped) {
+      if (groupedJps.has(e.jp)) continue;
+      seen.add(e.jp);
+      if (e.jp in serverGlossary) {
+        ungrouped.push({ jp: e.jp, zh: serverGlossary[e.jp] });
+      } else {
+        ungrouped.push(e);
+      }
+    }
     for (const jp of Object.keys(serverGlossary)) {
-      if (!groupedJps.has(jp)) {
+      if (!groupedJps.has(jp) && !seen.has(jp)) {
         ungrouped.push({ jp, zh: serverGlossary[jp] });
       }
     }

--- a/web/src/model/GlossaryGroup.ts
+++ b/web/src/model/GlossaryGroup.ts
@@ -10,9 +10,28 @@ function storageKey(novelId: string): string {
   return `${STORAGE_KEY_PREFIX}${novelId}`;
 }
 
+const ORDER_KEY = '_order';
+
+function readStoredOrder(novelId: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey(novelId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return [];
+    const order = parsed[ORDER_KEY];
+    return Array.isArray(order) ? order : [];
+  } catch {
+    return [];
+  }
+}
+
 export namespace GlossaryGroup {
   export function storageKeyFor(novelId: string): string {
     return storageKey(novelId);
+  }
+
+  export function getGroupOrder(novelId: string): string[] {
+    return readStoredOrder(novelId);
   }
 
   export function getGroups(novelId: string): GlossaryGroupMap {
@@ -21,7 +40,8 @@ export namespace GlossaryGroup {
       if (!raw) return {};
       const parsed = JSON.parse(raw);
       if (typeof parsed !== 'object' || parsed === null) return {};
-      return parsed as GlossaryGroupMap;
+      const { [ORDER_KEY]: _order, ...groups } = parsed;
+      return groups as GlossaryGroupMap;
     } catch {
       return {};
     }
@@ -30,8 +50,15 @@ export namespace GlossaryGroup {
   export function saveGroups(
     novelId: string,
     groups: GlossaryGroupMap,
+    order?: string[],
   ): boolean {
-    const json = JSON.stringify(groups);
+    const newOrder =
+      order ?? readStoredOrder(novelId).filter((k) => k in groups);
+    for (const key of Object.keys(groups)) {
+      if (!newOrder.includes(key)) newOrder.push(key);
+    }
+    const data = { [ORDER_KEY]: newOrder, ...groups };
+    const json = JSON.stringify(data);
     if (json.length > MAX_STORAGE_BYTES) {
       console.warn(`分组数据过大 (${json.length} bytes)，放弃保存`);
       return false;
@@ -103,7 +130,8 @@ export namespace GlossaryGroup {
     if (groups[newName] || !groups[oldName]) return false;
     groups[newName] = groups[oldName];
     delete groups[oldName];
-    return saveGroups(novelId, groups);
+    saveGroups(novelId, groups);
+    return true;
   }
 
   export function deleteGroup(novelId: string, groupName: string): void {
@@ -116,26 +144,29 @@ export namespace GlossaryGroup {
     const groups = getGroups(novelId);
     if (groups[groupName]) return false;
     groups[groupName] = [];
-    return saveGroups(novelId, groups);
+    saveGroups(novelId, groups);
+    return true;
   }
 
   /** 交叉比对：返回增补后的显示数据 */
   export function buildDisplayData(
     groups: GlossaryGroupMap,
     serverGlossary: Record<string, string>,
+    order?: string[],
   ): GlossaryGroupMap {
     const result: GlossaryGroupMap = {};
     const groupedJps = new Set<string>();
 
-    // 先复制所有本地分组
-    for (const [name, entries] of Object.entries(groups)) {
+    const names = order ?? Object.keys(groups);
+    for (const name of names) {
+      const entries = groups[name];
+      if (!entries) continue;
       result[name] = entries.map((e) => {
         groupedJps.add(e.jp);
-        // 如果服务端有这个术语，用服务端的 zh
         if (e.jp in serverGlossary) {
           return { jp: e.jp, zh: serverGlossary[e.jp] };
         }
-        return e; // 不在服务端 → 划线显示
+        return e;
       });
     }
 

--- a/web/src/model/GlossaryGroup.ts
+++ b/web/src/model/GlossaryGroup.ts
@@ -1,0 +1,155 @@
+export type GlossaryEntry = { jp: string; zh: string };
+
+export type GlossaryGroupMap = Record<string, GlossaryEntry[]>;
+
+const STORAGE_KEY_PREFIX = 'glossary-groups-';
+
+const MAX_STORAGE_BYTES = 4 * 1024 * 1024; // 4MB 保守上限
+
+function storageKey(novelId: string): string {
+  return `${STORAGE_KEY_PREFIX}${novelId}`;
+}
+
+export namespace GlossaryGroup {
+  export function storageKeyFor(novelId: string): string {
+    return storageKey(novelId);
+  }
+
+  export function getGroups(novelId: string): GlossaryGroupMap {
+    try {
+      const raw = localStorage.getItem(storageKey(novelId));
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null) return {};
+      return parsed as GlossaryGroupMap;
+    } catch {
+      return {};
+    }
+  }
+
+  export function saveGroups(
+    novelId: string,
+    groups: GlossaryGroupMap,
+  ): boolean {
+    const json = JSON.stringify(groups);
+    if (json.length > MAX_STORAGE_BYTES) {
+      console.warn(`分组数据过大 (${json.length} bytes)，放弃保存`);
+      return false;
+    }
+    try {
+      localStorage.setItem(storageKey(novelId), json);
+      return true;
+    } catch (e) {
+      console.warn('localStorage 写入失败，可能已满', e);
+      return false;
+    }
+  }
+
+  export function clearGroups(novelId: string): void {
+    localStorage.removeItem(storageKey(novelId));
+  }
+
+  /** 从所有分组中移除某个术语 */
+  export function removeTerm(novelId: string, jp: string): void {
+    const groups = getGroups(novelId);
+    let changed = false;
+    for (const name of Object.keys(groups)) {
+      const before = groups[name].length;
+      groups[name] = groups[name].filter((e) => e.jp !== jp);
+      if (groups[name].length !== before) changed = true;
+      if (groups[name].length === 0) delete groups[name];
+    }
+    if (changed) saveGroups(novelId, groups);
+  }
+
+  /** 将术语移入指定分组（自动从旧分组移除） */
+  export function moveTerm(
+    novelId: string,
+    jp: string,
+    zh: string,
+    groupName: string,
+  ): void {
+    const groups = getGroups(novelId);
+    removeTermFromAll(groups, jp);
+    if (!groups[groupName]) groups[groupName] = [];
+    groups[groupName].push({ jp, zh });
+    saveGroups(novelId, groups);
+  }
+
+  function removeTermFromAll(groups: GlossaryGroupMap, jp: string): void {
+    for (const name of Object.keys(groups)) {
+      groups[name] = groups[name].filter((e) => e.jp !== jp);
+      if (groups[name].length === 0) delete groups[name];
+    }
+  }
+
+  /** 获取术语所属的分组名，不在任何分组返回 undefined */
+  export function findGroup(
+    groups: GlossaryGroupMap,
+    jp: string,
+  ): string | undefined {
+    for (const [name, entries] of Object.entries(groups)) {
+      if (entries.some((e) => e.jp === jp)) return name;
+    }
+    return undefined;
+  }
+
+  export function renameGroup(
+    novelId: string,
+    oldName: string,
+    newName: string,
+  ): boolean {
+    const groups = getGroups(novelId);
+    if (groups[newName] || !groups[oldName]) return false;
+    groups[newName] = groups[oldName];
+    delete groups[oldName];
+    return saveGroups(novelId, groups);
+  }
+
+  export function deleteGroup(novelId: string, groupName: string): void {
+    const groups = getGroups(novelId);
+    delete groups[groupName];
+    saveGroups(novelId, groups);
+  }
+
+  export function addEmptyGroup(novelId: string, groupName: string): boolean {
+    const groups = getGroups(novelId);
+    if (groups[groupName]) return false;
+    groups[groupName] = [];
+    return saveGroups(novelId, groups);
+  }
+
+  /** 交叉比对：返回增补后的显示数据 */
+  export function buildDisplayData(
+    groups: GlossaryGroupMap,
+    serverGlossary: Record<string, string>,
+  ): GlossaryGroupMap {
+    const result: GlossaryGroupMap = {};
+    const groupedJps = new Set<string>();
+
+    // 先复制所有本地分组
+    for (const [name, entries] of Object.entries(groups)) {
+      result[name] = entries.map((e) => {
+        groupedJps.add(e.jp);
+        // 如果服务端有这个术语，用服务端的 zh
+        if (e.jp in serverGlossary) {
+          return { jp: e.jp, zh: serverGlossary[e.jp] };
+        }
+        return e; // 不在服务端 → 划线显示
+      });
+    }
+
+    // 未分组术语（在服务端但不在任何分组中）
+    const ungrouped: GlossaryEntry[] = [];
+    for (const jp of Object.keys(serverGlossary)) {
+      if (!groupedJps.has(jp)) {
+        ungrouped.push({ jp, zh: serverGlossary[jp] });
+      }
+    }
+    if (ungrouped.length > 0) {
+      result['未分组'] = ungrouped;
+    }
+
+    return result;
+  }
+}

--- a/web/src/model/GlossaryHistory.ts
+++ b/web/src/model/GlossaryHistory.ts
@@ -1,0 +1,117 @@
+import type { Glossary } from './Glossary';
+
+export type GlossaryHistoryType = 'submit' | 'remote-changed';
+
+export interface GlossaryHistoryEntry {
+  id: string;
+  novelId: string;
+  timestamp: number;
+  type: GlossaryHistoryType;
+  glossary: Glossary;
+  termCount: number;
+}
+
+const MAX_ENTRIES = 30;
+
+function storageKey(novelId: string): string {
+  return `glossary-history-${novelId}`;
+}
+
+function deepEqual(a: Glossary, b: Glossary): boolean {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((k) => a[k] === b[k]);
+}
+
+let _keysCache: string[] | null = null;
+const CACHE_DURATION = 5000;
+let _cacheTime = 0;
+
+export function getHistoryKeys(): string[] {
+  if (_keysCache && Date.now() - _cacheTime < CACHE_DURATION) {
+    return _keysCache;
+  }
+  const prefix = 'glossary-history-';
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(prefix)) {
+      keys.push(key.slice(prefix.length));
+    }
+  }
+  _keysCache = keys;
+  _cacheTime = Date.now();
+  return keys;
+}
+
+function invalidateKeysCache() {
+  _keysCache = null;
+}
+
+export function getHistory(novelId: string): GlossaryHistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(storageKey(novelId));
+    if (!raw) return [];
+    return JSON.parse(raw) as GlossaryHistoryEntry[];
+  } catch {
+    return [];
+  }
+}
+
+export function addHistory(
+  novelId: string,
+  entry: Omit<
+    GlossaryHistoryEntry,
+    'id' | 'timestamp' | 'novelId' | 'termCount'
+  > & {
+    glossary: Glossary;
+    type: GlossaryHistoryType;
+  },
+): boolean {
+  const items = getHistory(novelId);
+
+  // 去重：与最近一条 deep compare
+  const latest = items[items.length - 1];
+  if (latest && deepEqual(latest.glossary, entry.glossary)) {
+    return false;
+  }
+
+  const full: GlossaryHistoryEntry = {
+    id: crypto.randomUUID(),
+    novelId,
+    timestamp: Date.now(),
+    type: entry.type,
+    glossary: entry.glossary,
+    termCount: Object.keys(entry.glossary).length,
+  };
+
+  items.push(full);
+  while (items.length > MAX_ENTRIES) items.shift();
+
+  localStorage.setItem(storageKey(novelId), JSON.stringify(items));
+  invalidateKeysCache();
+  return true;
+}
+
+export function deleteHistory(novelId: string, entryId: string): void {
+  let items = getHistory(novelId);
+  items = items.filter((e) => e.id !== entryId);
+  if (items.length === 0) {
+    localStorage.removeItem(storageKey(novelId));
+    invalidateKeysCache();
+  } else {
+    localStorage.setItem(storageKey(novelId), JSON.stringify(items));
+  }
+}
+
+export function clearHistory(novelId: string): void {
+  localStorage.removeItem(storageKey(novelId));
+  invalidateKeysCache();
+}
+
+export function getLatestGlossary(novelId: string): Glossary | null {
+  const items = getHistory(novelId);
+  if (items.length === 0) return null;
+  return items[items.length - 1].glossary;
+}

--- a/web/src/pages/other/Setting.vue
+++ b/web/src/pages/other/Setting.vue
@@ -84,6 +84,10 @@ const playSound = (source: string) => {
           <n-checkbox v-model:checked="setting.hideCommmentWenkuNovel">
             隐藏文库小说评论
           </n-checkbox>
+          <b>术语表</b>
+          <n-checkbox v-model:checked="setting.useGlossaryGroups">
+            启用分组模式（桌面端）
+          </n-checkbox>
           <b>收藏夹</b>
           <n-checkbox v-model:checked="setting.showTagInWebFavored">
             显示收藏夹里网络小说的标签

--- a/web/src/stores/useSettingStore.ts
+++ b/web/src/stores/useSettingStore.ts
@@ -34,6 +34,7 @@ export interface Setting {
   //
   locale: 'zh-cn' | 'zh-tw';
   searchLocaleAware: boolean;
+  useGlossaryGroups: boolean;
 }
 
 export namespace Setting {
@@ -69,6 +70,7 @@ export namespace Setting {
     //
     locale: 'zh-cn',
     searchLocaleAware: false,
+    useGlossaryGroups: true,
   };
 
   export const migrate = (setting: Setting) => {
@@ -95,6 +97,10 @@ export namespace Setting {
     // 2024-05-28
     if ((setting.paginationMode as unknown) === 'auto') {
       setting.paginationMode = 'pagination';
+    }
+    // 2024-05-05
+    if (setting.useGlossaryGroups === undefined) {
+      setting.useGlossaryGroups = true;
     }
   };
 


### PR DESCRIPTION
## 功能

### 分组管理
- 术语按可拖拽标签页分组，支持新建/重命名/删除分组
- 术语在组内可拖拽排序，组间可拖拽移动
- 多选支持（Ctrl/Shift+Click），批量拖动入组
- 导航栏标签页可拖拽重排
- 组内支持时间排序、五十音排序
- 设置中可开关分组模式

### 编辑历史记录
- 提交术语表时自动保存快照到 localStorage
- 打开编辑框时检测远程变动，自动记录
- 历史查看弹窗以 diff 风格展示增/删/改（+/-/~）
- 支持恢复到历史版本、单条删除、清空全部

### 交互优化
- 点垃圾桶直接删除（从服务端和分组中同时移除），不再显示"回退"
- 日文/中文输入框：Enter 自动添加并回到日文框
- ZH 编辑框 Enter 结束编辑

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)