### PR TITLE
fix(web): 修复 vite8 下 vue 文件路径别名解析失败

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,5 +3,10 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
 }


### PR DESCRIPTION
## 问题

升级到 vite 8（#0f4a7d0b）后，运行 `pnpm dev` 报 `Failed to run dependency scan`，所有 `.vue` 文件中以 `@/` 开头的导入都无法解析（如 `@/util`、`@/stores`、`@/model/Common` 等）。

## 原因

vite 8 移除了 `vite-tsconfig-paths` 插件，改用内置的 `resolve.tsconfigPaths: true`。该实现底层调用 rolldown 的 `resolveTsconfig`，它通过文件后缀（`.ts` / `.tsx` 等）向上查找最近的 tsconfig，**不识别 `.vue`**，因此 `.vue` 文件不会进入 `tsconfig.app.json`，而是直接命中根 `tsconfig.json` —— 而根配置是空的 references-only 结构，没有 `paths`。

实测 `resolveTsconfig` 返回结果：

| 文件 | 命中的 tsconfig | paths |
|---|---|---|
| `src/main.ts` | `tsconfig.app.json` | ✓ |
| `src/pages/**/*.vue` | `tsconfig.json` | ✗ |

## 修改

在根 `tsconfig.json` 补上 `compilerOptions.paths`，让 `.vue` 文件查找路径别名时也能命中。

`tsconfig.app.json` 中的 `paths` 保留不动，以维持 `vue-tsc -b` 类型检查的正确性。

## 验证

- `pnpm dev` 启动正常，无 dependency scan 错误。