### PR TITLE
refactor: 章节 api 直接返回小说名称以简化阅读页 document.title 逻辑

### DIFF
--- a/server/src/main/kotlin/api/RouteWebNovel.kt
+++ b/server/src/main/kotlin/api/RouteWebNovel.kt
@@ -672,6 +672,8 @@ class WebNovelApi(
     data class ChapterDto(
         val titleJp: String,
         val titleZh: String?,
+        val novelTitleJp: String,
+        val novelTitleZh: String?,
         val prevId: String?,
         val nextId: String?,
         val paragraphs: List<String>,
@@ -700,6 +702,8 @@ class WebNovelApi(
         return ChapterDto(
             titleJp = toc[currIndex].titleJp,
             titleZh = toc[currIndex].titleZh,
+            novelTitleJp = novel.titleJp,
+            novelTitleZh = novel.titleZh,
             prevId = toc.getOrNull(currIndex - 1)?.chapterId,
             nextId = toc.getOrNull(currIndex + 1)?.chapterId,
             paragraphs = chapter.paragraphs,

--- a/web/src/model/WebNovel.ts
+++ b/web/src/model/WebNovel.ts
@@ -55,6 +55,8 @@ export interface WebNovelDto {
 export interface WebNovelChapterDto {
   titleJp: string;
   titleZh?: string;
+  novelTitleJp?: string;
+  novelTitleZh?: string;
   prevId?: string;
   nextId?: string;
   paragraphs: string[];

--- a/web/src/pages/reader/Reader.vue
+++ b/web/src/pages/reader/Reader.vue
@@ -5,7 +5,7 @@ import { ReadHistoryApi } from '@/api';
 import { GenericNovelId } from '@/model/Common';
 import type { TranslatorId } from '@/model/Translator';
 import { checkIsMobile } from '@/pages/util';
-import { ReadPositionRepo, WebNovelRepo } from '@/repos';
+import { ReadPositionRepo } from '@/repos';
 import {
   useLocalVolumeStore,
   useReaderSettingStore,
@@ -48,13 +48,6 @@ const gnid = ((): GenericNovelId => {
 
 const store = useReaderStore(gnid);
 
-// 仅 web 小说需要获取小说元数据，用于在 document.title 中拼接小说名称
-const novelQuery =
-  gnid.type === 'web'
-    ? WebNovelRepo.useWebNovel(gnid.providerId, gnid.novelId)
-    : undefined;
-const novel = novelQuery?.data;
-
 const targetChapterId = ref('');
 const currentChapterId = ref('');
 const chapterResult = shallowRef<Result<ReaderChapter>>();
@@ -69,22 +62,15 @@ const novelUrl = (() => {
   }
 })();
 
-// 组合阅读页 document.title，显示「章节名称 | 小说名称」，小说元数据未就绪时仅显示章节名称
-const applyDocumentTitle = (chapter: ReaderChapter) => {
-  if (gnid.type === 'web' && novel?.value?.titleJp) {
-    document.title = `${chapter.titleJp} | ${novel.value.titleJp}`;
-  } else {
-    document.title = chapter.titleJp;
-  }
-};
-
 const updateChapter = (
   chapterId: string,
   result: Result<ReaderChapter>,
   replace = false,
 ) => {
   if (result.ok) {
-    applyDocumentTitle(result.value);
+    document.title = result.value.novelTitleJp
+      ? `${result.value.titleJp} | ${result.value.novelTitleJp}`
+      : result.value.titleJp;
     if (gnid.type === 'web' && whoami.value.isSignedIn) {
       ReadHistoryApi.updateReadHistoryWeb(
         gnid.providerId,
@@ -115,16 +101,6 @@ const updateChapter = (
     router.push(`${prefix}/${chapterId}`);
   }
 };
-
-// 章节通常比小说元数据先到达，首次 updateChapter 时 novel 可能仍为 undefined，导致 title 暂时只有章节名
-// 元数据到达后由此 watch 重套一次，补上小说名称
-if (novel !== undefined) {
-  watch(novel, () => {
-    if (chapterResult.value?.ok) {
-      applyDocumentTitle(chapterResult.value.value);
-    }
-  });
-}
 
 const navToChapter = async (chapterId: string) => {
   targetChapterId.value = chapterId;

--- a/web/src/pages/reader/ReaderStore.ts
+++ b/web/src/pages/reader/ReaderStore.ts
@@ -8,6 +8,8 @@ export interface ReaderChapter {
   chapterId: string;
   titleJp: string;
   titleZh?: string;
+  novelTitleJp?: string;
+  novelTitleZh?: string;
   prevId?: string;
   nextId?: string;
   paragraphs: string[];


### PR DESCRIPTION
## 背景

#340 让网络小说阅读页的 `document.title` 显示「章节名 | 小说名」，但实现上前端在 `Reader.vue` 中额外发起了一次 `useWebNovel` 查询来拿小说名称，并因为章节通常比小说元数据先到达，还需要一个 `watch` 兜底重写 title。

## 改动

让章节 api 在响应里直接带上小说名称，前端不再需要额外查询：

- `server`：`ChapterDto` 新增 `novelTitleJp` / `novelTitleZh`，由 `getChapter` 从 novel 元数据填入。
- `web`：
  - `WebNovelChapterDto` / `ReaderChapter` 同步新增字段。
  - `Reader.vue` 移除 `useWebNovel` 查询及对应的 `watch`，`document.title` 在 `updateChapter` 内一次性根据 `result.value.novelTitleJp` 拼接。

## 影响

- 阅读页加载时少一次 `/web/{providerId}/{novelId}` 请求。
- `document.title` 不再有「先只显示章节名、随后补上小说名」的闪动。
- 用户可见行为与 #340 一致。