### PR TITLE
feat(web): WEB翻译独立包 [3] 实现基础翻译工作流

### DIFF
--- a/packages/translation/src/index.ts
+++ b/packages/translation/src/index.ts
@@ -1,3 +1,5 @@
 import { createTranslator } from './translator';
+import { DefaultTranslationPipeline } from './pipeline/translation_pipeline';
+import { DefaultSegmentQueue } from './segment';
 
-export { createTranslator };
+export { createTranslator, DefaultTranslationPipeline, DefaultSegmentQueue };

--- a/packages/translation/src/pipeline/translation_pipeline.ts
+++ b/packages/translation/src/pipeline/translation_pipeline.ts
@@ -1,0 +1,146 @@
+import { Semaphore } from '@/utils';
+import {
+  TranslationHistory,
+  TranslationLoop,
+  TranslationPipeline,
+  SegmentQueue,
+  Translator,
+  LineSegmenter,
+  SegmentAssembler,
+  Glossary,
+} from '@/types';
+import { createLineSegmenter, createSegmentAssembler } from '@/segment';
+
+export class DefaultTranslationPipeline extends TranslationPipeline {
+  private segmenter: LineSegmenter;
+  private assembler: SegmentAssembler;
+
+  constructor(
+    queue: SegmentQueue,
+    segmenter?: LineSegmenter,
+    assembler?: SegmentAssembler,
+  ) {
+    super(queue);
+    this.segmenter = segmenter ?? createLineSegmenter(1500, 30);
+    this.assembler = assembler ?? createSegmentAssembler();
+  }
+
+  async translate(
+    text: string,
+    glossary?: Glossary,
+    history?: TranslationHistory,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    signal?.throwIfAborted();
+
+    const lines = text.split('\n');
+    const ranges = this.segmenter.segment(lines);
+    glossary = glossary ?? {};
+
+    type Deferred = {
+      resolve: (value: { order: number; text: string }) => void;
+      reject: (reason: any) => void;
+    };
+    const deferredMap = new Map<number, Deferred>();
+
+    const segments = this.assembler.assemble(
+      crypto.randomUUID(),
+      lines,
+      ranges,
+      glossary,
+      (segment, translatedLines) => {
+        deferredMap.get(segment.order)?.resolve({
+          order: segment.order,
+          text: translatedLines.join('\n'),
+        });
+      },
+      (segment, reason) => {
+        deferredMap.get(segment.order)?.reject(reason);
+      },
+      history,
+    );
+
+    const segmentPromises: Promise<{ order: number; text: string }>[] = [];
+    for (const seg of segments) {
+      const promise = new Promise<{ order: number; text: string }>(
+        (resolve, reject) => {
+          deferredMap.set(seg.order, { resolve, reject });
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        },
+      );
+      segmentPromises.push(promise);
+    }
+
+    this.queue.enqueueAll(segments);
+    const results = await Promise.allSettled(segmentPromises);
+    const finalSegments = results.map((result, index) => {
+      if (result.status === 'fulfilled') {
+        return result.value;
+      } else {
+        // 如果该分片翻译失败或被取消，返回原文
+        return {
+          order: segments[index].order,
+          text: segments[index].lines.join('\n'),
+        };
+      }
+    });
+    return finalSegments
+      .sort((a, b) => a.order - b.order)
+      .map((r) => r.text)
+      .join('\n');
+  }
+
+  waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void> {
+    return this.queue.waitUntilBelowHighWaterMark(signal);
+  }
+
+  registerTranslator(translator: Translator, concurrency?: number): void {
+    const id = crypto.randomUUID();
+    const loop: TranslationLoop = {
+      id,
+      translator,
+      abortController: new AbortController(),
+      concurrency: concurrency ?? 1,
+    };
+    this.translatorLoops.set(id, loop);
+    this._startLoop(loop);
+  }
+
+  private async _startLoop(loop: TranslationLoop): Promise<void> {
+    const semaphore = new Semaphore(loop.concurrency ?? 1);
+    while (!loop.abortController.signal.aborted) {
+      try {
+        const segment = await this.queue.dequeue(loop.abortController.signal);
+
+        semaphore.use(async () => {
+          if (loop.abortController.signal.aborted) return;
+          try {
+            const translatedLines = await loop.translator.translate(
+              segment.lines,
+              segment.context,
+              loop.abortController.signal,
+            );
+            segment.onComplete(segment, translatedLines);
+          } catch (err: any) {
+            if (err.name === 'AbortError') return;
+            segment.onError(segment, err);
+          }
+        });
+      } catch (err) {
+        if (loop.abortController.signal.aborted) break;
+      }
+    }
+  }
+
+  unregisterTranslator(translator: Translator): void {
+    for (const [id, loop] of this.translatorLoops) {
+      if (loop.translator === translator) {
+        loop.abortController.abort();
+        this.translatorLoops.delete(id);
+        break;
+      }
+    }
+  }
+}

--- a/packages/translation/src/pipeline/translation_pipeline.ts
+++ b/packages/translation/src/pipeline/translation_pipeline.ts
@@ -10,19 +10,18 @@ import {
   Glossary,
 } from '@/types';
 import { createLineSegmenter, createSegmentAssembler } from '@/segment';
+import { DefaultSegmentQueue } from '@/segment';
 
 export class DefaultTranslationPipeline extends TranslationPipeline {
+  protected queue: SegmentQueue;
   private segmenter: LineSegmenter;
   private assembler: SegmentAssembler;
 
-  constructor(
-    queue: SegmentQueue,
-    segmenter?: LineSegmenter,
-    assembler?: SegmentAssembler,
-  ) {
-    super(queue);
+  constructor(highWaterMark?: number, segmenter?: LineSegmenter) {
+    super();
+    this.queue = new DefaultSegmentQueue(highWaterMark ?? 50);
     this.segmenter = segmenter ?? createLineSegmenter(1500, 30);
-    this.assembler = assembler ?? createSegmentAssembler();
+    this.assembler = createSegmentAssembler();
   }
 
   async translate(
@@ -90,10 +89,6 @@ export class DefaultTranslationPipeline extends TranslationPipeline {
       .sort((a, b) => a.order - b.order)
       .map((r) => r.text)
       .join('\n');
-  }
-
-  waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void> {
-    return this.queue.waitUntilBelowHighWaterMark(signal);
   }
 
   registerTranslator(translator: Translator, concurrency?: number): void {

--- a/packages/translation/src/pipeline/translation_pipeline.ts
+++ b/packages/translation/src/pipeline/translation_pipeline.ts
@@ -63,15 +63,24 @@ export class DefaultTranslationPipeline extends TranslationPipeline {
     for (const seg of segments) {
       const promise = new Promise<{ order: number; text: string }>(
         (resolve, reject) => {
-          deferredMap.set(seg.order, { resolve, reject });
-          signal?.addEventListener('abort', () => reject(signal.reason), {
-            once: true,
+          const onAbort = () => reject(signal?.reason);
+          signal?.addEventListener('abort', onAbort, { once: true });
+          deferredMap.set(seg.order, {
+            resolve: (val) => {
+              signal?.removeEventListener('abort', onAbort);
+              resolve(val);
+            },
+            reject: (err) => {
+              signal?.removeEventListener('abort', onAbort);
+              reject(err);
+            },
           });
         },
       );
       segmentPromises.push(promise);
     }
 
+    await this.waitUntilBelowHighWaterMark(signal);
     this.queue.enqueueAll(segments);
     const results = await Promise.allSettled(segmentPromises);
     const finalSegments = results.map((result, index) => {
@@ -134,7 +143,6 @@ export class DefaultTranslationPipeline extends TranslationPipeline {
       if (loop.translator === translator) {
         loop.abortController.abort();
         this.translatorLoops.delete(id);
-        break;
       }
     }
   }

--- a/packages/translation/src/segment/index.ts
+++ b/packages/translation/src/segment/index.ts
@@ -1,3 +1,3 @@
 export { createSegmentAssembler } from './segment_assembler';
 export { createLineSegmenter } from './segmenter';
-export { SegmentQueueImpl } from './segment_queue';
+export { DefaultSegmentQueue } from './segment_queue';

--- a/packages/translation/src/segment/segment_queue.ts
+++ b/packages/translation/src/segment/segment_queue.ts
@@ -1,6 +1,6 @@
 import type { Segment, SegmentQueue } from '@/types';
 
-export class SegmentQueueImpl implements SegmentQueue {
+export class DefaultSegmentQueue implements SegmentQueue {
   private readonly _items: Segment[] = [];
   private readonly _highWaterMark: number;
 
@@ -12,7 +12,7 @@ export class SegmentQueueImpl implements SegmentQueue {
   private _hwPromise: Promise<void> | null = null;
 
   constructor(highWaterMark: number) {
-    this._highWaterMark = highWaterMark;
+    this._highWaterMark = Math.max(1, highWaterMark);
   }
 
   get length(): number {
@@ -24,59 +24,86 @@ export class SegmentQueueImpl implements SegmentQueue {
   }
 
   enqueueAll(segments: Segment[]): void {
-    if (segments.length === 0) return;
+    const segLen = segments.length;
+    if (segLen === 0) return;
 
-    this._items.push(...segments);
+    const resolverLen = this._dequeueResolvers.length;
+    const matchCount = Math.min(segLen, resolverLen);
 
-    // 逐个唤醒等待的消费者（一个 segment 唤醒一个消费者）
-    let idx = 0;
-    while (idx < segments.length && this._dequeueResolvers.length > 0) {
-      const resolve = this._dequeueResolvers.shift()!;
-      const seg = this._items.shift()!;
-      resolve(seg);
-      idx++;
+    if (matchCount > 0) {
+      for (let i = 0; i < matchCount; i++) {
+        this._dequeueResolvers[i](segments[i]);
+      }
+      this._dequeueResolvers.splice(0, matchCount);
     }
-
-    this.#tryResolveHw();
+    if (segLen > matchCount) {
+      for (let i = matchCount; i < segLen; i++) {
+        this._items.push(segments[i]);
+      }
+    }
   }
 
-  dequeue(): Promise<Segment> {
+  async dequeue(signal?: AbortSignal): Promise<Segment> {
+    signal?.throwIfAborted();
+
     if (this._items.length > 0) {
       const item = this._items.shift()!;
-      this.#tryResolveHw();
-      return Promise.resolve(item);
+      this._tryResolveHw();
+      return item;
     }
-    return new Promise<Segment>((resolve) => {
-      this._dequeueResolvers.push(resolve);
+    return new Promise<Segment>((resolve, reject) => {
+      const onAbort = () => {
+        const idx = this._dequeueResolvers.indexOf(dequeueResolver);
+        if (idx !== -1) this._dequeueResolvers.splice(idx, 1);
+        reject(signal!.reason);
+      };
+      const dequeueResolver = (seg: Segment) => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve(seg);
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+      this._dequeueResolvers.push(dequeueResolver);
     });
   }
 
-  waitUntilBelowHighWaterMark(): Promise<void> {
-    if (this._items.length < this._highWaterMark) {
-      return Promise.resolve();
+  async waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
+
+    if (this._items.length < this._highWaterMark) return;
+
+    if (!this._hwPromise) {
+      this._hwPromise = new Promise<void>((resolve) => {
+        this._hwResolver = resolve;
+      });
     }
 
-    // 复用已有的 Promise，避免多个等待者冲突
-    if (this._hwPromise) {
-      return this._hwPromise;
-    }
+    if (!signal) return this._hwPromise;
 
-    this._hwPromise = new Promise<void>((resolve) => {
-      this._hwResolver = resolve;
+    return new Promise((resolve, reject) => {
+      const onAbort = () => reject(signal.reason);
+      signal.addEventListener('abort', onAbort, { once: true });
+
+      this._hwPromise!.then(
+        () => {
+          signal.removeEventListener('abort', onAbort);
+          resolve();
+        },
+        (err) => {
+          signal.removeEventListener('abort', onAbort);
+          reject(err);
+        },
+      );
     });
-
-    return this._hwPromise;
   }
 
   /** 检查并尝试唤醒等待水位下降的生产者 */
-  #tryResolveHw(): void {
+  private _tryResolveHw(): void {
     if (this._hwResolver && this._items.length < this._highWaterMark) {
       const resolve = this._hwResolver;
-      const promise = this._hwPromise!;
       this._hwResolver = null;
       this._hwPromise = null;
       resolve();
-      promise.catch(() => {});
     }
   }
 }

--- a/packages/translation/src/translator/openai/translator_openai.ts
+++ b/packages/translation/src/translator/openai/translator_openai.ts
@@ -26,6 +26,7 @@ export class OpenAiTranslator implements Translator {
   async translate(
     lines: string[],
     context?: SegmentContext,
+    signal?: AbortSignal,
   ): Promise<string[]> {
     if (lines.length === 0) return [];
 
@@ -33,7 +34,7 @@ export class OpenAiTranslator implements Translator {
     let failBecauseLineNumberNotMatch = 0;
 
     while (retry < 3) {
-      const result = await this.translateLines(lines, context);
+      const result = await this.translateLines(lines, context, signal);
 
       if (lines.length !== result.length) {
         failBecauseLineNumberNotMatch++;
@@ -51,7 +52,7 @@ export class OpenAiTranslator implements Translator {
 
     // 仅当连续3次行数不匹配且行数大于1时，启动二分翻译
     if (failBecauseLineNumberNotMatch === 3 && lines.length > 1) {
-      return this.binaryTranslate(lines, context);
+      return this.binaryTranslate(lines, context, signal);
     }
     throw new Error('翻译失败：重试次数过多');
   }
@@ -59,15 +60,19 @@ export class OpenAiTranslator implements Translator {
   private async translateLines(
     lines: string[],
     context?: SegmentContext,
+    signal?: AbortSignal,
   ): Promise<string[]> {
     const messages = this.promptBuilder(lines, context);
-    const completion = await this.api.createChatCompletions({
-      model: this.model,
-      messages,
-      temperature: 0.1,
-      top_p: 0.3,
-      max_tokens: Math.max(Math.ceil(lines.join('').length * 1.7), 100),
-    });
+    const completion = await this.api.createChatCompletions(
+      {
+        model: this.model,
+        messages,
+        temperature: 0.1,
+        top_p: 0.3,
+        max_tokens: Math.max(Math.ceil(lines.join('').length * 1.7), 100),
+      },
+      { signal },
+    );
 
     const content = completion.choices[0]?.message?.content ?? '';
     return this.parseAnswer(content);
@@ -88,11 +93,18 @@ export class OpenAiTranslator implements Translator {
   private async binaryTranslate(
     lines: string[],
     context?: SegmentContext,
+    signal?: AbortSignal,
   ): Promise<string[]> {
     const binary = async (left: number, right: number): Promise<string[]> => {
+      signal?.throwIfAborted();
+
       if (left >= right) return [];
       if (right - left === 1) {
-        const result = await this.translateLines([lines[left]], context);
+        const result = await this.translateLines(
+          [lines[left]],
+          context,
+          signal,
+        );
         return result.length === 1 ? result : [lines[left]];
       }
 

--- a/packages/translation/src/translator/sakura/translator_sakura.ts
+++ b/packages/translation/src/translator/sakura/translator_sakura.ts
@@ -29,6 +29,7 @@ export class SakuraTranslator implements Translator {
   async translate(
     lines: string[],
     context?: SegmentContext,
+    signal?: AbortSignal,
   ): Promise<string[]> {
     if (lines.length === 0) return [];
     const prevSegs = context?.prevSegs ?? [];
@@ -44,6 +45,7 @@ export class SakuraTranslator implements Translator {
         lines,
         translateContext,
         retry > 0,
+        signal,
       );
 
       const splitText = text.replaceAll('<|im_end|>', '').split('\n');
@@ -54,7 +56,7 @@ export class SakuraTranslator implements Translator {
       }
       retry++;
     }
-    return this.translateLineByLine(lines, translateContext);
+    return this.translateLineByLine(lines, translateContext, signal);
   }
 
   private truncatePrevSegs(prevSegs: string[][]): string[][] {
@@ -77,19 +79,23 @@ export class SakuraTranslator implements Translator {
     lines: string[],
     context?: SegmentContext,
     hasDegradation?: boolean,
+    signal?: AbortSignal,
   ): Promise<{ text: string; hasDegradation: boolean }> {
     const messages = this.promptBuilder(lines, context);
     const text = lines.join('\n');
     const maxNewToken = Math.max(Math.ceil(text.length * 1.7), 100);
 
-    const completion = await this.api.createChatCompletions({
-      model: '',
-      messages,
-      temperature: 0.1,
-      top_p: 0.3,
-      max_tokens: maxNewToken,
-      frequency_penalty: hasDegradation ? 0.2 : 0.0,
-    });
+    const completion = await this.api.createChatCompletions(
+      {
+        model: '',
+        messages,
+        temperature: 0.1,
+        top_p: 0.3,
+        max_tokens: maxNewToken,
+        frequency_penalty: hasDegradation ? 0.2 : 0.0,
+      },
+      { signal },
+    );
 
     return {
       text: completion.choices[0]?.message?.content ?? '',
@@ -100,12 +106,15 @@ export class SakuraTranslator implements Translator {
   private async translateLineByLine(
     lines: string[],
     context?: SegmentContext,
+    signal?: AbortSignal,
   ): Promise<string[]> {
     const prevSegs = context?.prevSegs ?? [];
     const resultPerLine: string[] = [];
     let degradationLineCount = 0;
 
     for (const line of lines) {
+      signal?.throwIfAborted();
+
       const lineContext: SegmentContext = {
         ...context,
         prevSegs: [...prevSegs, resultPerLine],
@@ -115,6 +124,7 @@ export class SakuraTranslator implements Translator {
         [line],
         lineContext,
         true,
+        signal,
       );
 
       if (hasDegradation) {

--- a/packages/translation/src/types.ts
+++ b/packages/translation/src/types.ts
@@ -74,10 +74,6 @@ export interface Translator {
   ): Promise<string[]>;
 }
 
-export interface PipelineConfig {
-  highWaterMark: number;
-}
-
 export interface TranslationLoop {
   id: string;
   translator: Translator;
@@ -87,13 +83,11 @@ export interface TranslationLoop {
 }
 
 export abstract class TranslationPipeline {
-  protected config: PipelineConfig;
   protected queue: SegmentQueue;
   protected translatorLoops: Map<string, TranslationLoop>;
   protected visualizer?: Visualizer;
 
-  constructor(config: PipelineConfig, queue: SegmentQueue) {
-    this.config = config;
+  constructor(queue: SegmentQueue) {
     this.queue = queue;
     this.translatorLoops = new Map();
   }

--- a/packages/translation/src/types.ts
+++ b/packages/translation/src/types.ts
@@ -83,12 +83,11 @@ export interface TranslationLoop {
 }
 
 export abstract class TranslationPipeline {
-  protected queue: SegmentQueue;
+  protected abstract queue: SegmentQueue;
   protected translatorLoops: Map<string, TranslationLoop>;
   protected visualizer?: Visualizer;
 
-  constructor(queue: SegmentQueue) {
-    this.queue = queue;
+  constructor() {
     this.translatorLoops = new Map();
   }
 
@@ -98,7 +97,11 @@ export abstract class TranslationPipeline {
     history?: TranslationHistory,
     signal?: AbortSignal,
   ): Promise<string>;
-  abstract waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void>;
+
+  waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void> {
+    return this.queue.waitUntilBelowHighWaterMark(signal);
+  }
+
   abstract registerTranslator(
     translator: Translator,
     concurrency?: number,

--- a/packages/translation/src/types.ts
+++ b/packages/translation/src/types.ts
@@ -57,8 +57,8 @@ export abstract class SegmentQueue {
   abstract readonly length: number;
   abstract readonly highWaterMark: number;
   abstract enqueueAll(segments: Segment[]): void;
-  abstract dequeue(): Promise<Segment>;
-  abstract waitUntilBelowHighWaterMark(): Promise<void>;
+  abstract dequeue(signal?: AbortSignal): Promise<Segment>;
+  abstract waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void>;
 }
 
 export type PromptBuilder = (
@@ -67,7 +67,11 @@ export type PromptBuilder = (
 ) => Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
 
 export interface Translator {
-  translate(lines: string[], context?: SegmentContext): Promise<string[]>;
+  translate(
+    lines: string[],
+    context?: SegmentContext,
+    signal?: AbortSignal,
+  ): Promise<string[]>;
 }
 
 export interface PipelineConfig {
@@ -78,6 +82,8 @@ export interface TranslationLoop {
   id: string;
   translator: Translator;
   abortController: AbortController;
+  //并发数不提供时默认 1 并发
+  concurrency?: number;
 }
 
 export abstract class TranslationPipeline {
@@ -94,10 +100,15 @@ export abstract class TranslationPipeline {
 
   abstract translate(
     text: string,
+    glossary?: Glossary,
     history?: TranslationHistory,
+    signal?: AbortSignal,
   ): Promise<string>;
-  abstract waitUntilBelowHighWaterMark(): Promise<void>;
-  abstract registerTranslator(translator: Translator): void;
+  abstract waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void>;
+  abstract registerTranslator(
+    translator: Translator,
+    concurrency?: number,
+  ): void;
   abstract unregisterTranslator(translator: Translator): void;
 }
 

--- a/packages/translation/src/utils.ts
+++ b/packages/translation/src/utils.ts
@@ -100,3 +100,58 @@ export const delay = (ms: number, signal?: AbortSignal) =>
     }, ms);
     signal?.addEventListener('abort', abortHandler);
   });
+
+export class Semaphore {
+  private current = 0;
+  private queue: Array<() => void> = [];
+  constructor(private max: number) {
+    if (max <= 0)
+      throw new Error('Semaphore max capacity must be greater than 0');
+  }
+
+  private async _acquire(): Promise<void> {
+    if (this.current < this.max) {
+      this.current++;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private _release(): void {
+    if (this.queue.length > 0) {
+      const next = this.queue.shift()!;
+      next();
+    } else {
+      this.current--;
+    }
+  }
+
+  setMax(max: number): void {
+    if (max <= 0)
+      throw new Error('Semaphore max capacity must be greater than 0');
+    this.max = max;
+    while (this.queue.length > 0 && this.current < this.max) {
+      this.current++;
+      const next = this.queue.shift()!;
+      next();
+    }
+  }
+
+  async use<T>(fn: () => Promise<T> | T): Promise<T> {
+    await this._acquire();
+    let released = false;
+    const safeRelease = () => {
+      if (!released) {
+        released = true;
+        this._release();
+      }
+    };
+    try {
+      return await fn();
+    } finally {
+      safeRelease();
+    }
+  }
+}

--- a/packages/translation/tests/segment_queue.test.ts
+++ b/packages/translation/tests/segment_queue.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { SegmentQueueImpl } from '../src/segment';
+import { DefaultSegmentQueue } from '../src/segment';
 import type { Segment } from '../src/types';
 
-describe('SegmentQueueImpl', () => {
-  let queue: SegmentQueueImpl;
+describe('DefaultSegmentQueue', () => {
+  let queue: DefaultSegmentQueue;
   const HWM = 3; // 设置高水位线为 3，方便测试
 
   // 模拟数据的辅助函数
@@ -11,7 +11,7 @@ describe('SegmentQueueImpl', () => {
     ({ id, text: `content-${id}` }) as any;
 
   beforeEach(() => {
-    queue = new SegmentQueueImpl(HWM);
+    queue = new DefaultSegmentQueue(HWM);
   });
 
   // --- 场景 1：基础功能 ---

--- a/packages/translation/tsconfig.json
+++ b/packages/translation/tsconfig.json
@@ -14,6 +14,7 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
+    "forceConsistentCasingInFileNames": true,
     "outDir": "./dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
* 增加abort signal机制。
* 实现翻译包中的基础工作流 DefaultTranslationPipeLine，通过 translate 函数翻译完整的文本。
```javascript
translate(
    text: string,
    glossary?: Glossary,
    history?: TranslationHistory,
    signal?: AbortSignal,
  ): Promise<string>;
```

测试代码：
```javascript
import {
  createTranslator,
  DefaultTranslationPipeline,
  DefaultSegmentQueue,
} from './packages/translation/dist/index.js';

import { readFileSync, writeFileSync } from 'node:fs';

// ---- 配置 ----
const INPUT_FILE = '待翻译文本路径';
const OUTPUT_FILE = '输出翻译文本路径';
const CONCURRENCY = 10; // 并发数

const text = readFileSync(INPUT_FILE, 'utf-8');
console.log(`输入文件: ${INPUT_FILE}`);
console.log(`文本长度: ${text.length} 字符`);
console.log(`行数: ${text.split('\n').length} 行`);
console.log(`并发数: ${CONCURRENCY}`);
console.log('---');

const translator = createTranslator({
  type: 'openai',
  endpoint: 'https://api.deepseek.com/v1',
  key: '',
  model: 'deepseek-chat',
});

// ---- 创建 Pipeline ----
const highWaterMark = 50;
const pipeline = new DefaultTranslationPipeline(highWaterMark);

pipeline.registerTranslator(translator, CONCURRENCY);

console.log('开始翻译...');
const startTime = Date.now();

try {
  const translated = await pipeline.translate(text,{
    "「": "「",
    "」": "」"
  });

  const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
  console.log(`翻译完成，耗时 ${elapsed} 秒`);

  writeFileSync(OUTPUT_FILE, translated, 'utf-8');
  console.log(`译文已写入: ${OUTPUT_FILE}`);
  console.log(`译文长度: ${translated.length} 字符`);
} catch (err) {
  console.error('翻译失败:', err);
  process.exit(1);
}
```

* 未实现：
  * Sakura的翻译流中 在待翻译文段前填充已翻译的上下文 的逻辑。
  * 视觉组件（其应该在每个Segment状态更新时，和整个翻译任务状态变化时 触发一些显示更新函数）。
  * 对于各个Segment中错误的处理（目前错误时，返回的翻译文本的是原文，最终组装时是一起组装的。）

整体流程图如下：

<img width="600" alt="image" src="https://github.com/user-attachments/assets/c4a7d39f-c473-4e5b-bb92-6145a01a8e24" />
