### PR TITLE
修复登录刷新冷却与匿名重试

### DIFF
--- a/web/src/util/useUserData/index.ts
+++ b/web/src/util/useUserData/index.ts
@@ -84,22 +84,32 @@ function useUserDataWithAuth(app: string) {
     userData.value.profile = undefined;
   }
 
+  let skipAnonymousRefresh = false;
+
   const refresh = () =>
     AuthApi.refresh(app).then((token: string) => {
       userData.value.profile = parseJwt(token);
+      skipAnonymousRefresh = false;
     });
 
   const refreshIfNeeded = () => {
     // 刷新 Access Token，冷却时间为1小时
     const cooldown = 60 * 60 * 1000;
-    const sinceIssuedAt =
-      Date.now() - (userData.value.profile?.issuedAt ?? 0) * 1000;
+    const profile = userData.value.profile;
+    if (!profile && skipAnonymousRefresh) {
+      return;
+    }
+    const sinceIssuedAt = Date.now() - (profile?.issuedAt ?? 0) * 1000;
     if (sinceIssuedAt < cooldown) {
       return;
     }
     return refresh().catch(async (e: unknown) => {
       let msg = `${e}`;
       if (e instanceof HTTPError) {
+        if (e.response.status === 401) {
+          userData.value.profile = undefined;
+          skipAnonymousRefresh = true;
+        }
         msg = await e.response.text();
       }
       console.warn('更新授权失败：' + msg);
@@ -112,6 +122,7 @@ function useUserDataWithAuth(app: string) {
 
   const logout = () => {
     userData.value.profile = undefined;
+    skipAnonymousRefresh = true;
     return AuthApi.logout();
   };
 

--- a/web/src/util/useUserData/index.ts
+++ b/web/src/util/useUserData/index.ts
@@ -92,7 +92,8 @@ function useUserDataWithAuth(app: string) {
   const refreshIfNeeded = () => {
     // 刷新 Access Token，冷却时间为1小时
     const cooldown = 60 * 60 * 1000;
-    const sinceIssuedAt = Date.now() - (userData.value.profile?.issuedAt ?? 0);
+    const sinceIssuedAt =
+      Date.now() - (userData.value.profile?.issuedAt ?? 0) * 1000;
     if (sinceIssuedAt < cooldown) {
       return;
     }


### PR DESCRIPTION
## 变更

修复两个登录刷新问题：

- JWT `iat` 是秒，`Date.now()` 是毫秒，刷新冷却判断前先把 `iat` 转成毫秒。
- `/auth/refresh` 返回 401 后，停止未登录状态下每 15 分钟重复刷新，避免持续产生无效请求。

## 风险

如果页面已经收到过 401，它不会再靠定时刷新自动恢复登录状态。用户在其他标签页登录后，当前页面需要走正常登录回调触发 `refresh()`，或刷新页面后恢复。
