### PR TITLE
refactor(web): 将Translator包内翻译器的parseAnswer（输出解析）逻辑提出到promptBuilder中，并优化OpenAI翻译器的parseAnswer

### DIFF
--- a/packages/translator/src/translator/openai-prompt.ts
+++ b/packages/translator/src/translator/openai-prompt.ts
@@ -46,7 +46,7 @@ export const createOpenAiPromptBuilder = (): PromptBuilder => {
       const trimmed = line.trim();
       if (!trimmed) continue;
 
-      const match = trimmed.match(/^#(\d+)[:：]?\s*(.*)/);
+      const match = trimmed.match(/^#(\d+)([:：]|\s+)(.*)/);
       if (match) {
         const lineNum = parseInt(match[1]);
         const content = match[2];

--- a/packages/translator/src/translator/openai-prompt.ts
+++ b/packages/translator/src/translator/openai-prompt.ts
@@ -1,7 +1,7 @@
 import type { PromptBuilder, SegmentContext } from '@/types';
 
 export const createOpenAiPromptBuilder = (): PromptBuilder => {
-  return (lines: string[], context?: SegmentContext) => {
+  const build = (lines: string[], context?: SegmentContext) => {
     const glossary = context?.glossary ?? {};
     const messages: Array<{
       role: 'system' | 'user' | 'assistant';
@@ -38,4 +38,40 @@ export const createOpenAiPromptBuilder = (): PromptBuilder => {
     messages.push({ role: 'user', content: parts.join('\n') });
     return messages;
   };
+
+  const parseAnswer = (answer: string, originalLines: string[]): string[] => {
+    const lineContentMap = new Map<number, string>();
+
+    for (const line of answer.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      const match = trimmed.match(/^#(\d+)[:：]?\s*(.*)/);
+      if (match) {
+        const lineNum = parseInt(match[1]);
+        const content = match[2];
+        lineContentMap.set(lineNum, content);
+      }
+    }
+
+    const result: string[] = [];
+    for (let i = 0; i < originalLines.length; i++) {
+      const lineNum = i + 1;
+      const originalLine = originalLines[i];
+
+      if (originalLine.trim().length === 0) {
+        result.push(originalLine);
+      } else {
+        const translated = lineContentMap.get(lineNum);
+        if (translated === undefined) {
+          throw new Error(`行数未对齐`);
+        }
+        const heading = originalLine.match(/^(\s*)/)?.[1] ?? '';
+        result.push(heading + translated);
+      }
+    }
+    return result;
+  };
+
+  return { build, parseAnswer };
 };

--- a/packages/translator/src/translator/openai-prompt.ts
+++ b/packages/translator/src/translator/openai-prompt.ts
@@ -64,7 +64,7 @@ export const createOpenAiPromptBuilder = (): PromptBuilder => {
       } else {
         const translated = lineContentMap.get(lineNum);
         if (translated === undefined) {
-          throw new Error(`行数未对齐`);
+          throw new Error(`行数不匹配`);
         }
         const heading = originalLine.match(/^(\s*)/)?.[1] ?? '';
         result.push(heading + translated);

--- a/packages/translator/src/translator/openai-translator.ts
+++ b/packages/translator/src/translator/openai-translator.ts
@@ -54,7 +54,7 @@ export class OpenAiTranslator implements Translator {
         result = await this.translateLines(lines, context, signal);
       } catch (err: any) {
         if (err.name === 'AbortError') throw err;
-        this.log(`API 错误：${err}`);
+        this.log(`翻译错误：${err}`);
         retry++;
         continue;
       }
@@ -88,19 +88,12 @@ export class OpenAiTranslator implements Translator {
     context?: SegmentContext,
     signal?: AbortSignal,
   ): Promise<string[]> {
-    const parseAnswer = (answer: string) => {
-      return answer
-        .split('\n')
-        .filter((s) => s.trim())
-        .map((s, i) =>
-          s
-            .replace(`#${i + 1}:`, '')
-            .replace(`#${i + 1}：`, '')
-            .trim(),
-        );
-    };
+    if (lines.length === 0) return [];
+    if (lines.every((l) => l.trim().length === 0)) {
+      return lines;
+    }
 
-    const messages = this.promptBuilder(lines, context);
+    const messages = this.promptBuilder.build(lines, context);
     const completion = await this.api.createChatCompletions(
       {
         model: this.model,
@@ -110,7 +103,7 @@ export class OpenAiTranslator implements Translator {
     );
 
     const content = completion.choices[0]?.message?.content ?? '';
-    return parseAnswer(content);
+    return this.promptBuilder.parseAnswer(content, lines);
   }
 
   private async binaryTranslate(

--- a/packages/translator/src/translator/sakura-prompt.ts
+++ b/packages/translator/src/translator/sakura-prompt.ts
@@ -56,7 +56,7 @@ export const allowModels: {
 export const createSakuraPromptBuilder = (
   version: SakuraVersion,
 ): PromptBuilder => {
-  return (lines: string[], context?: SegmentContext) => {
+  const build = (lines: string[], context?: SegmentContext) => {
     const glossary = context?.glossary ?? {};
     const prevSegs = context?.prevSegs;
     const messages: Array<{
@@ -139,4 +139,11 @@ export const createSakuraPromptBuilder = (
 
     return messages;
   };
+
+  const parseAnswer = (answer: string, _originalLines: string[]): string[] => {
+    const splitText = answer.replaceAll('<|im_end|>', '').split('\n');
+    return splitText;
+  };
+
+  return { build, parseAnswer };
 };

--- a/packages/translator/src/translator/sakura-translator.ts
+++ b/packages/translator/src/translator/sakura-translator.ts
@@ -127,7 +127,7 @@ export class SakuraTranslator implements Translator {
         continue;
       }
 
-      const splitText = text.replaceAll('<|im_end|>', '').split('\n');
+      const splitText = this.promptBuilder.parseAnswer(text, lines);
       const linesNotMatched = lines.length !== splitText.length;
       const parts: string[] = [`第${retry + 1}次`];
       if (hasDegradation) {
@@ -201,7 +201,7 @@ export class SakuraTranslator implements Translator {
     hasDegradation?: boolean,
     signal?: AbortSignal,
   ): Promise<{ text: string; hasDegradation: boolean }> {
-    const messages = this.promptBuilder(lines, context);
+    const messages = this.promptBuilder.build(lines, context);
     const text = lines.join('\n');
     const maxNewToken = Math.max(Math.ceil(text.length * 1.7), 100);
 

--- a/packages/translator/src/types.ts
+++ b/packages/translator/src/types.ts
@@ -61,10 +61,13 @@ export abstract class SegmentQueue {
   abstract waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void>;
 }
 
-export type PromptBuilder = (
-  lines: string[],
-  context?: SegmentContext,
-) => Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
+export interface PromptBuilder {
+  build: (
+    lines: string[],
+    context?: SegmentContext,
+  ) => Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
+  parseAnswer: (answer: string, originalLines: string[]) => string[];
+}
 
 export type Logger = (message: string, detail?: string[]) => void;
 


### PR DESCRIPTION
fix #367 and 重构LLM的输出解析。

#367 的问题一可以通过正则来去除行号匹配译文部分：/^#(\d+)([:：]|\s+)(.*)/
#367 的问题二：在OpenAI翻译器中，对于一个全空白行的segment，还是会发送到API请求翻译，导致模型回答 “小说内容不完整”。这个在此PR中通过在 `translateLines` 中手动判断来修复。

而之所以会有全空白行，一方面是切分segment时，目前是最大每30行切一块，如果刚好最后的几行是空白的，则会出现全空白行的segment。另一方面是，翻译有问题，触发了二分翻译，导致二分过程中出现全空白行的segment。

分析了下二分翻译的原因，大部分是触发了行数不匹配（输出中，空白行被省略）：
```
原文：
#1:空白
#2:原文
#3:空白
#4:原文

模型输出
#2:译文
#4:译文
``` 
而上述情况之所谓被判断为 行数不匹配，是因为OpenAI翻译器现有的parseAnswer：
```
const parseAnswer = (answer: string) => {
      return answer
        .split('\n')
        .filter((s) => s.trim())
        .map((s, i) =>
          s
            .replace(`#${i + 1}:`, '')
            .replace(`#${i + 1}：`, '')
            .trim(),
        );
    };
```
仅仅做了去除 #N 的每行标记，而未对每行进行更加智能的匹配。

所以重构一下，将 parseAnswer 移到 promptBuilder 中。
因为 promptBuilder 既然有构建prompt和在prompt中说明回复格式的功能， 那么也应该负责模型输出的解析。

更新了PromptBuilder目前的类型定义，并适配了Sakura和OpenAI两个翻译器的PromptBuilder：
```
export interface PromptBuilder {
  build: (
    lines: string[],
    context?: SegmentContext,
  ) => Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
  parseAnswer: (answer: string, originalLines: string[]) => string[];
}
```

对于OpenAI翻译器，新写的parseAnswer逻辑如下：

进行逐行匹配：
原文一行为空，输出一行为空
原文一行非空，根据其行号在译文中提取 #N 前缀，未找到则报“行数不匹配”的错误，找到后用译文来替换这一行（保留原文行首空格）。