### PR TITLE
feat(web): GPT Pipeline 工作区

### DIFF
--- a/web/src/components/SectionHeader.vue
+++ b/web/src/components/SectionHeader.vue
@@ -6,11 +6,10 @@ defineProps<{ title: string }>();
   <n-flex
     align="baseline"
     justify="space-between"
-    :wrap="false"
-    style="width: 100"
+    style="width: 100%; row-gap: 2px"
   >
-    <n-h2 prefix="bar">{{ title }}</n-h2>
-    <n-flex :wrap="false">
+    <n-h2 prefix="bar" style="flex-shrink: 0">{{ title }}</n-h2>
+    <n-flex style="flex-shrink: 0">
       <slot />
     </n-flex>
   </n-flex>

--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -1,11 +1,447 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import {
+  BookOutlined,
+  DeleteOutlineOutlined,
+  PlusOutlined,
+} from '@vicons/material';
+import { VueDraggable } from 'vue-draggable-plus';
+import { OpenAiTranslator, TranslationPipeline } from '@auto-novel/translator';
+import type { TranslatorTracker } from '@auto-novel/translator';
+
+import { doAction } from '@/pages/util';
+import { useGptPipelineWorkspaceStore, useWorkspaceStore } from '@/stores';
+import { TaskExecutor } from '@/domain/translator/TaskExecutor';
+import { IndexedDbSegmentCache } from '@/domain/translator/IndexedDbSegmentCache';
+import { createTranslationTask } from '@/domain/translator/TranslationTask/createTranslationTask';
+import type { TranslationTask } from '@/domain/translator/TranslationTask/types';
+import { TaskState } from '@/domain/translator/TaskState';
+import type { ChapterStatus } from '@/domain/translator/TaskState';
+import type { TranslateJob, TranslateJobRecord } from '@/model/Translator';
+import { TranslateTaskDescriptor } from '@/model/Translator';
+
+const message = useMessage();
+const pipelineWorkspace = useGptPipelineWorkspaceStore();
+const gptWorkspace = useWorkspaceStore('gpt'); // 暂时与旧版 GPT 共享任务队列
+const jobs = computed(() => gptWorkspace.ref.value.jobs);
+
+const showWorkerModal = ref(false);
+const showLocalVolumeDrawer = ref(false);
+
+// ========== 任务状态管理 ==========
+
+const taskStates = ref(new Map<string, TaskState>());
+const taskCache = new Map<string, TranslationTask>();
+
+interface WorkerState {
+  running: boolean;
+  concurrency: { current: number; max: number };
+}
+const workerStates = ref(new Map<string, WorkerState>());
+const workerErrors = computed(() => {
+  const errors = new Map<string, number>();
+  for (const [, state] of taskStates.value) {
+    for (const [, chapterState] of state.chapterStates) {
+      for (const seg of chapterState.segments) {
+        if (seg.status === 'error' && seg.translatorId) {
+          errors.set(seg.translatorId, (errors.get(seg.translatorId) ?? 0) + 1);
+        }
+      }
+    }
+  }
+  return errors;
+});
+const executingTasks = reactive(new Set<string>());
+
+const pipeline = new TranslationPipeline(
+  100,
+  undefined,
+  new IndexedDbSegmentCache('gpt-seg-cache'),
+);
+let processLoopAbortController: AbortController | null = null;
+let processLoopPromise: Promise<void> | null = null;
+
+// ========== 任务过滤 ==========
+
+type TaskFilter = 'all' | 'done' | 'pending';
+const taskFilter = ref<TaskFilter>('all');
+
+const filterOptions: { label: string; value: TaskFilter }[] = [
+  { label: '全部', value: 'all' },
+  { label: '已完成', value: 'done' },
+  { label: '未完成', value: 'pending' },
+];
+
+function getTaskStatus(taskDesc: string): TaskFilter {
+  const job = jobs.value.find((j) => j.task === taskDesc);
+  return job?.finishAt ? 'done' : 'pending';
+}
+
+const filteredJobs = computed(() => {
+  if (taskFilter.value === 'all') return jobs.value;
+  return jobs.value.filter((j) => getTaskStatus(j.task) === taskFilter.value);
+});
+
+async function getOrCreateTask(taskDesc: string): Promise<TranslationTask> {
+  let task = taskCache.get(taskDesc);
+  if (!task) {
+    const { desc, params } = TranslateTaskDescriptor.parse(taskDesc);
+    task = createTranslationTask(desc, 'gpt', params);
+    taskCache.set(taskDesc, task);
+  }
+  return task;
+}
+
+// ========== 全局滑动窗口 ==========
+
+/** 同时处理的章节数 */
+const GLOBAL_WINDOW = 3;
+
+function getNextJob(
+  jobs: TranslateJob[],
+  taskStatesMap: Map<string, TaskState>,
+): { job: TranslateJob; chapterId: string } | null {
+  for (const job of jobs) {
+    if (job.finishAt) continue;
+    const state = taskStatesMap.get(job.task);
+    if (!state) continue;
+    for (const ch of state.chapters) {
+      if (ch.status !== 'pending') continue;
+      return { job, chapterId: ch.chapterId };
+    }
+  }
+  return null;
+}
+
+function countPendingChapters(
+  jobs: TranslateJob[],
+  taskStatesMap: Map<string, TaskState>,
+): number {
+  let count = 0;
+  for (const job of jobs) {
+    if (job.finishAt) continue;
+    const state = taskStatesMap.get(job.task);
+    if (!state) continue;
+    for (const ch of state.chapters) {
+      if (ch.status === 'pending') count++;
+    }
+  }
+  return count;
+}
+
+// ========== 全局处理循环 ==========
+
+function runProcessLoop(): Promise<void> | null {
+  if (processLoopPromise) return processLoopPromise;
+
+  processLoopAbortController = new AbortController();
+  const signal = processLoopAbortController.signal;
+
+  const processOne = async () => {
+    while (!signal.aborted) {
+      const item = getNextJob(jobs.value, taskStates.value);
+      if (!item) break;
+
+      const { job, chapterId } = item;
+      executingTasks.add(job.task);
+
+      const state = taskStates.value.get(job.task);
+      if (!state) continue;
+
+      const ch = state.chapters.find((c) => c.chapterId === chapterId);
+      if (ch) ch.status = 'translating';
+
+      const task = await getOrCreateTask(job.task);
+      const executor = new TaskExecutor(task, pipeline);
+
+      const segmentTracker = state.getOrCreateChapterState(chapterId);
+      await executor.executeChapter(
+        chapterId,
+        {
+          onChapterStatus: (cid: string, st: ChapterStatus) => {
+            state.updateChapterStatus(cid, st);
+          },
+          onProgress: (finished: number, error: number, total: number) => {
+            (job as TranslateJobRecord).progress = { finished, error, total };
+          },
+          onLog: (msg: string) => console.log(`[${job.task}] ${msg}`),
+          segmentTracker,
+        },
+        signal,
+      );
+    }
+  };
+
+  const pendingCount = countPendingChapters(jobs.value, taskStates.value);
+  const windowSize = Math.min(GLOBAL_WINDOW, pendingCount || 1);
+  const workers = Array.from({ length: windowSize }, () => processOne());
+
+  processLoopPromise = Promise.all(workers).then(() => {
+    for (const t of [...executingTasks]) {
+      executingTasks.delete(t);
+      const state = taskStates.value.get(t);
+      if (state && state.chapters.every((c) => c.status === 'done')) {
+        const job = jobs.value.find((j) => j.task === t);
+        if (job) job.finishAt = Date.now();
+      }
+    }
+    processLoopPromise = null;
+    processLoopAbortController = null;
+  });
+
+  return processLoopPromise;
+}
+
+// ========== Worker 生命周期管理 ==========
+
+const startWorker = (workerId: string) => {
+  if (workerStates.value.get(workerId)?.running) return;
+
+  const w = pipelineWorkspace.ref.value.workers.find((w) => w.id === workerId);
+  if (!w) {
+    message.error(`翻译器 ${workerId} 不存在`);
+    return;
+  }
+
+  workerStates.value.set(workerId, {
+    running: true,
+    concurrency: { current: 0, max: w.concurrency },
+  });
+
+  const t = new OpenAiTranslator({
+    endpoint: w.endpoint,
+    key: w.key,
+    model: w.model,
+  });
+
+  const workerTracker: TranslatorTracker = {
+    onConcurrencyChange: (current: number, max: number) => {
+      const state = workerStates.value.get(w.id);
+      if (state) state.concurrency = { current, max };
+    },
+  };
+  pipeline.registerTranslator(t, w.concurrency, workerTracker, w.id);
+
+  runProcessLoop();
+};
+
+const stopWorker = (workerId: string) => {
+  const state = workerStates.value.get(workerId);
+  if (!state?.running) return;
+
+  pipeline.unregisterTranslator(workerId);
+
+  workerStates.value.set(workerId, { ...state, running: false });
+
+  if ([...workerStates.value.values()].every((s) => !s.running)) {
+    processLoopAbortController?.abort();
+    processLoopAbortController = null;
+    processLoopPromise = null;
+  }
+};
+
+const startAllWorkers = () => {
+  for (const w of pipelineWorkspace.ref.value.workers) startWorker(w.id);
+};
+
+const stopAllWorkers = () => {
+  for (const w of pipelineWorkspace.ref.value.workers) stopWorker(w.id);
+};
+
+const deleteJob = (task: string) => {
+  if (executingTasks.has(task)) {
+    message.error('任务正在翻译中');
+    return;
+  }
+  gptWorkspace.deleteJob(task);
+  taskStates.value.delete(task);
+  taskCache.delete(task);
+};
+
+const deleteAllJobs = () =>
+  filteredJobs.value.forEach((j) => deleteJob(j.task));
+
+const clearCache = () =>
+  doAction(
+    new IndexedDbSegmentCache('gpt-seg-cache').clear(),
+    '缓存清除',
+    message,
+  );
+
+watch(
+  () => [...jobs.value],
+  async (jobs) => {
+    const pending: TranslateJob[] = [];
+    for (const job of jobs) {
+      if (taskStates.value.get(job.task)?.chapters.length) continue;
+      if (job.finishAt) {
+        taskStates.value.set(
+          job.task,
+          reactive(new TaskState(job.task)) as TaskState,
+        );
+        continue;
+      }
+      pending.push(job);
+    }
+    await Promise.all(
+      pending.map(async (job) => {
+        try {
+          const task = await getOrCreateTask(job.task);
+          await task.initMeta();
+          const chapters = task.chapters;
+          const state = reactive(new TaskState(job.task)) as TaskState;
+          state.chapters = chapters;
+          taskStates.value.set(job.task, state);
+          const doneCount = chapters.filter((c) => c.status === 'done').length;
+          (job as TranslateJobRecord).progress = {
+            finished: doneCount,
+            error: 0,
+            total: chapters.length,
+          };
+          if (chapters.length > 0 && doneCount === chapters.length) {
+            job.finishAt = Date.now();
+          }
+        } catch (e) {
+          console.warn('任务初始化失败', job.task, e);
+        }
+      }),
+    );
+  },
+  { immediate: true },
+);
+</script>
 
 <template>
   <div class="layout-content">
-    <n-h1>GPT工作区 BETA</n-h1>
+    <n-h1>GPT工作区BETA</n-h1>
+    <bulletin>
+      <n-p>
+        支持并发和查看章节分块状态的新GPT工作区。目前处于测试阶段，有问题请在群内反馈。
+      </n-p>
+    </bulletin>
 
-    <n-alert type="info" title="开发中">
-      GPT翻译器管线的网页部分，目前未实现。
-    </n-alert>
+    <section-header title="翻译器" />
+
+    <n-flex vertical>
+      <c-action-wrapper title="操作" align="center">
+        <n-button-group size="small">
+          <c-button
+            label="添加翻译器"
+            :icon="PlusOutlined"
+            :round="false"
+            @action="showWorkerModal = true"
+          />
+          <c-button label="启动全部" :round="false" @action="startAllWorkers" />
+          <c-button label="停止全部" :round="false" @action="stopAllWorkers" />
+          <c-button-confirm
+            hint="真的要清空缓存吗？"
+            label="清空缓存"
+            :icon="DeleteOutlineOutlined"
+            :round="false"
+            @action="clearCache"
+          />
+        </n-button-group>
+      </c-action-wrapper>
+    </n-flex>
+
+    <n-empty
+      v-if="pipelineWorkspace.ref.value.workers.length === 0"
+      description="没有翻译器"
+    />
+    <n-list v-else class="worker-list">
+      <vue-draggable
+        v-model="pipelineWorkspace.ref.value.workers"
+        :animation="150"
+        handle=".drag-trigger"
+        filter=".is-running"
+      >
+        <n-list-item
+          v-for="w of pipelineWorkspace.ref.value.workers"
+          :key="w.id"
+          :class="{ 'is-running': workerStates.get(w.id)?.running }"
+        >
+          <pipeline-worker-card
+            :worker="w"
+            :running="!!workerStates.get(w.id)?.running"
+            :concurrency="
+              workerStates.get(w.id)?.concurrency ?? {
+                current: 0,
+                max: w.concurrency,
+              }
+            "
+            :error-count="workerErrors.get(w.id) ?? 0"
+            @start="startWorker"
+            @stop="stopWorker"
+            @delete="pipelineWorkspace.deleteWorker"
+          />
+        </n-list-item>
+      </vue-draggable>
+    </n-list>
+
+    <section-header title="任务队列">
+      <c-button
+        label="本地书架"
+        :icon="BookOutlined"
+        @action="showLocalVolumeDrawer = true"
+      />
+    </section-header>
+
+    <n-flex vertical>
+      <c-action-wrapper title="状态">
+        <c-radio-group
+          v-model:value="taskFilter"
+          :options="filterOptions"
+          size="small"
+        />
+      </c-action-wrapper>
+      <c-action-wrapper title="操作" align="center">
+        <n-button-group size="small">
+          <c-button-confirm
+            hint="真的要删除筛选出的任务吗？"
+            label="删除筛选任务"
+            :icon="DeleteOutlineOutlined"
+            :round="false"
+            @action="deleteAllJobs"
+          />
+        </n-button-group>
+      </c-action-wrapper>
+    </n-flex>
+    <n-divider style="margin: 16px 0 8px" />
+    <n-empty v-if="filteredJobs.length === 0" description="没有任务" />
+    <div v-else class="task-list">
+      <pipeline-task-card
+        v-for="job of filteredJobs"
+        :key="job.task"
+        :job="job"
+        :task-states="taskStates"
+        :executing-tasks="executingTasks"
+        @delete="deleteJob"
+        @top="
+          (task: string) =>
+            gptWorkspace.topJob(
+              jobs.find((j: { task: string }) => j.task === task)!,
+            )
+        "
+        @bottom="
+          (task: string) =>
+            gptWorkspace.bottomJob(
+              jobs.find((j: { task: string }) => j.task === task)!,
+            )
+        "
+      />
+    </div>
   </div>
+
+  <local-volume-list-specific-translation
+    v-model:show="showLocalVolumeDrawer"
+    type="gpt"
+  />
+  <gpt-pipeline-worker-modal v-model:show="showWorkerModal" />
 </template>
+
+<style scoped>
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+</style>

--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -60,6 +60,13 @@ const pipeline = new TranslationPipeline(
 let processLoopAbortController: AbortController | null = null;
 let processLoopPromise: Promise<void> | null = null;
 
+onUnmounted(() => {
+  pipeline.clearLoops();
+  processLoopAbortController?.abort();
+  processLoopAbortController = null;
+  processLoopPromise = null;
+  executingTasks.clear();
+});
 // ========== 任务过滤 ==========
 
 type TaskFilter = 'all' | 'done' | 'pending';

--- a/web/src/pages/workspace/components/ChapterGrid.vue
+++ b/web/src/pages/workspace/components/ChapterGrid.vue
@@ -1,0 +1,168 @@
+<script lang="ts" setup>
+import type { ChapterMeta } from '@/domain/translator/TaskState';
+
+defineProps<{ chapters: ChapterMeta[] }>();
+
+const emit = defineEmits<{
+  preview: [chapterId: string];
+}>();
+
+const themeVars = useThemeVars();
+
+function pct(sp: { completed: number; total: number } | undefined): number {
+  if (!sp || sp.total <= 0) return 0;
+  return Math.round((sp.completed / sp.total) * 100);
+}
+</script>
+
+<template>
+  <div class="grid">
+    <n-tooltip v-for="(ch, i) of chapters" :key="ch.chapterId" placement="top">
+      <template #trigger>
+        <n-button
+          class="c"
+          :focusable="false"
+          :class="`c--${ch.status}`"
+          :style="{ '--i': i }"
+          quaternary
+          @click="emit('preview', ch.chapterId)"
+        >
+          <span class="o">{{ ch.order }}</span>
+          <span v-if="ch.segmentProgress" class="p">
+            {{ ch.segmentProgress.completed }}/{{ ch.segmentProgress.total }}
+          </span>
+
+          <n-progress
+            v-if="ch.segmentProgress && ch.status !== 'done'"
+            type="line"
+            :percentage="pct(ch.segmentProgress)"
+            :height="3"
+            :show-indicator="false"
+            :fill-border-radius="0"
+            class="bar"
+          />
+        </n-button>
+      </template>
+      {{ ch.title || `第 ${ch.order} 章` }}
+    </n-tooltip>
+  </div>
+</template>
+
+<style scoped>
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+  gap: 2px;
+}
+.c {
+  aspect-ratio: 1;
+  padding: 2px;
+  border: 1px solid v-bind('themeVars.borderColor');
+  color: v-bind('themeVars.textColor3');
+  animation: in 0.3s ease both;
+  animation-delay: calc(var(--i, 0) * 15ms);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+.c :deep(.n-button__content) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  height: 100%;
+}
+@keyframes in {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+.c--translating {
+  --pulse-from: color-mix(
+    in srgb,
+    v-bind('themeVars.infoColor') 0%,
+    transparent
+  );
+  --pulse-to: color-mix(
+    in srgb,
+    v-bind('themeVars.infoColor') 15%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    v-bind('themeVars.infoColor') 10%,
+    transparent
+  );
+  color: v-bind('themeVars.infoColor');
+  border-color: color-mix(
+    in srgb,
+    v-bind('themeVars.infoColor') 35%,
+    transparent
+  );
+  animation:
+    in 0.3s ease both,
+    pulse 2s infinite;
+  animation-delay: calc(var(--i, 0) * 15ms), calc(var(--i, 0) * 15ms + 0.5s);
+}
+@keyframes pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--pulse-from);
+  }
+  50% {
+    box-shadow: 0 0 0 3px var(--pulse-to);
+  }
+}
+.c--done {
+  background: color-mix(
+    in srgb,
+    v-bind('themeVars.successColor') 10%,
+    transparent
+  );
+  color: v-bind('themeVars.successColor');
+  border-color: color-mix(
+    in srgb,
+    v-bind('themeVars.successColor') 35%,
+    transparent
+  );
+}
+.c--error {
+  background: color-mix(
+    in srgb,
+    v-bind('themeVars.errorColor') 10%,
+    transparent
+  );
+  color: v-bind('themeVars.errorColor');
+  border-color: color-mix(
+    in srgb,
+    v-bind('themeVars.errorColor') 35%,
+    transparent
+  );
+}
+.o {
+  position: relative;
+  z-index: 1;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+}
+.p {
+  position: relative;
+  z-index: 1;
+  font-size: 8px;
+  line-height: 1;
+  opacity: 0.75;
+}
+.bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+</style>

--- a/web/src/pages/workspace/components/ChapterPreviewModal.vue
+++ b/web/src/pages/workspace/components/ChapterPreviewModal.vue
@@ -1,0 +1,241 @@
+<script lang="ts" setup>
+import type { ChapterSegmentState } from '@/domain/translator/TaskState';
+
+const themeVars = useThemeVars();
+
+const props = defineProps<{
+  show: boolean;
+  title: string;
+  chapterState: ChapterSegmentState | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:show', val: boolean): void;
+}>();
+
+const selectedSegmentIndex = ref(0);
+const previewState = computed(() => {
+  const state = props.chapterState;
+  const seg = state?.segments[selectedSegmentIndex.value] ?? null;
+  const paragraphs: { jp: string; zh: string }[] = [];
+  if (seg) {
+    const maxLen = Math.max(seg.lines.length, seg.translatedLines.length);
+    for (let i = 0; i < maxLen; i++) {
+      paragraphs.push({
+        jp: seg.lines[i] ?? '',
+        zh: seg.translatedLines[i] ?? '',
+      });
+    }
+  }
+
+  const errorMsgPrefix = seg?.translatorId ? `[${seg?.translatorId}] ` : '';
+  const rawError =
+    seg && seg.status === 'error'
+      ? state?.getSegmentError(selectedSegmentIndex.value)
+      : undefined;
+  const errorMsg = rawError ? `${errorMsgPrefix}${rawError}`.trim() : undefined;
+
+  return {
+    currentSegment: seg,
+    previewParagraphs: paragraphs,
+    currentSegmentError: errorMsg,
+    segmentStatuses: state
+      ? state.segments.map((s) => s?.status ?? 'pending')
+      : [],
+    previewProgressStatus:
+      state && state.segments.length > 0
+        ? {
+            total: state.segments.length,
+            success: state.completedCount,
+            processing: state.translatingCount,
+            failed: state.errorCount,
+          }
+        : null,
+    ranges: state?.ranges ?? [],
+  };
+});
+
+const segmentBtnType = (
+  status: string,
+): 'default' | 'success' | 'warning' | 'error' | 'info' => {
+  switch (status) {
+    case 'done':
+      return 'success';
+    case 'error':
+      return 'error';
+    case 'translating':
+      return 'info';
+    default:
+      return 'default';
+  }
+};
+
+const getSegmentError = (index: number): string | undefined => {
+  return props.chapterState?.getSegmentError(index);
+};
+
+const selectSegment = (index: number) => {
+  selectedSegmentIndex.value = index;
+};
+
+const onUpdateShow = (val: boolean) => {
+  if (!val) {
+    selectedSegmentIndex.value = 0;
+  }
+  emit('update:show', val);
+};
+</script>
+
+<template>
+  <c-modal
+    :show="show"
+    @update:show="onUpdateShow"
+    :title="title"
+    style="width: min(900px, 95vw)"
+  >
+    <template #header-extra>
+      <div class="preview-header-extra">
+        <div v-if="previewState.previewProgressStatus" class="preview-stats">
+          <n-tag size="small" :bordered="false">
+            共 {{ previewState.previewProgressStatus.total }}
+          </n-tag>
+          <n-tag size="small" :bordered="false" type="success">
+            ✓ {{ previewState.previewProgressStatus.success }}
+          </n-tag>
+          <n-tag size="small" :bordered="false" type="info">
+            ● {{ previewState.previewProgressStatus.processing }}
+          </n-tag>
+          <n-tag size="small" :bordered="false" type="error">
+            ✕ {{ previewState.previewProgressStatus.failed }}
+          </n-tag>
+        </div>
+        <n-divider style="margin: 4px 0 4px" />
+      </div>
+    </template>
+
+    <div v-if="previewState.ranges.length > 1" class="segment-tabs">
+      <n-button
+        v-for="(range, i) of previewState.ranges"
+        :key="i"
+        size="small"
+        secondary
+        :type="segmentBtnType(previewState.segmentStatuses[i])"
+        :title="getSegmentError(i) ?? range.end - range.start + '行'"
+        :class="{ active: selectedSegmentIndex === i }"
+        :style="
+          selectedSegmentIndex === i
+            ? {
+                outline: `2px solid ${themeVars.primaryColor}`,
+                outlineOffset: '1px',
+              }
+            : undefined
+        "
+        @click="selectSegment(i)"
+      >
+        {{ i + 1 }}
+      </n-button>
+    </div>
+
+    <n-alert
+      v-if="previewState.currentSegmentError"
+      type="error"
+      title="翻译出错"
+      :bordered="false"
+    >
+      <pre class="preview-error-message">{{
+        previewState.currentSegmentError
+      }}</pre>
+    </n-alert>
+
+    <n-table :bordered="false" size="small" class="preview-table">
+      <thead>
+        <tr>
+          <th style="width: 50%">原文</th>
+          <th style="width: 50%">译文</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(p, i) of previewState.previewParagraphs" :key="i">
+          <td class="preview-jp">{{ p.jp }}</td>
+          <td class="preview-zh">
+            <template v-if="p.zh">{{ p.zh }}</template>
+            <span v-else-if="p.jp" class="preview-none">（无译文）</span>
+          </td>
+        </tr>
+      </tbody>
+    </n-table>
+  </c-modal>
+</template>
+
+<style scoped>
+.preview-header-extra {
+  margin-top: -20px;
+}
+.preview-stats {
+  display: flex;
+  gap: 8px;
+}
+.segment-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 2px;
+}
+.segment-tabs .n-button {
+  min-width: 0;
+  padding-inline: 0;
+  aspect-ratio: 1;
+}
+.preview-table {
+  margin-top: 8px;
+  table-layout: fixed;
+}
+.preview-table td {
+  vertical-align: top;
+  line-height: 1.7;
+}
+
+@media (min-width: 769px) {
+  .preview-jp,
+  .preview-zh {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .preview-table thead {
+    display: none;
+  }
+  .preview-table tr {
+    display: block;
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.2);
+  }
+  .preview-table td {
+    display: block;
+    width: 100% !important;
+    padding: 3px 8px;
+    border: none;
+  }
+  .preview-jp {
+    font-weight: 500;
+    opacity: 1;
+  }
+  .preview-zh {
+    opacity: 0.6;
+  }
+}
+
+.preview-none {
+  opacity: 0.5;
+}
+.preview-error-message {
+  margin: 0;
+  font-size: 13px;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.5;
+}
+</style>

--- a/web/src/pages/workspace/components/GptPipelineWorkerModal.vue
+++ b/web/src/pages/workspace/components/GptPipelineWorkerModal.vue
@@ -1,0 +1,188 @@
+<script lang="ts" setup>
+import type { FormInst, FormItemRule, FormRules } from 'naive-ui';
+
+import type { GptPipelineWorker } from '@/model/Translator';
+import { useGptPipelineWorkspaceStore } from '@/stores';
+
+const props = defineProps<{
+  show: boolean;
+  worker?: GptPipelineWorker;
+}>();
+const emit = defineEmits<{
+  'update:show': [boolean];
+}>();
+
+const workspace = useGptPipelineWorkspaceStore();
+const workspaceRef = workspace.ref;
+
+const initFormValue = (
+  worker: GptPipelineWorker | undefined,
+): {
+  id: string;
+  model: string;
+  endpoint: string;
+  key: string;
+  concurrency: number;
+} => {
+  if (worker === undefined) {
+    return {
+      id: '',
+      model: 'deepseek-chat',
+      endpoint: 'https://api.deepseek.com',
+      key: '',
+      concurrency: 1,
+    };
+  } else {
+    return {
+      id: worker.id,
+      model: worker.model,
+      endpoint: worker.endpoint,
+      key: worker.key,
+      concurrency: worker.concurrency,
+    };
+  }
+};
+
+const formRef = useTemplateRef<FormInst>('form');
+const formValue = ref(initFormValue(props.worker));
+
+watch(
+  () => props.worker,
+  (newWorker) => {
+    formValue.value = initFormValue(newWorker);
+  },
+  { immediate: false },
+);
+
+const emptyCheck = (name: string) => ({
+  validator: (rule: FormItemRule, value: string) => value.trim().length > 0,
+  message: name + '不能为空',
+  trigger: 'input',
+});
+
+const formRules: FormRules = {
+  id: [
+    emptyCheck('名字'),
+    {
+      validator: (rule: FormItemRule, value: string) =>
+        workspaceRef.value.workers
+          .filter((w) => w.id !== props.worker?.id)
+          .find((w) => w.id === value) === undefined,
+      message: '名字不能重复',
+      trigger: 'input',
+    },
+  ],
+  model: [emptyCheck('模型')],
+  endpoint: [
+    emptyCheck('链接'),
+    {
+      validator: (rule: FormItemRule, value: string) => {
+        try {
+          const url = new URL(value);
+          return url.protocol === 'http:' || url.protocol === 'https:';
+        } catch (_) {
+          return false;
+        }
+      },
+      message: '链接不合法',
+      trigger: 'input',
+    },
+  ],
+  key: [
+    emptyCheck('Key'),
+    {
+      level: 'warning',
+      validator: (rule: FormItemRule, value: string) =>
+        workspaceRef.value.workers
+          .filter((w) => w.id !== props.worker?.id)
+          .find((w) => w.key === value) === undefined,
+      message: '有重复的Key，请确保使用的API支持并发',
+      trigger: 'input',
+    },
+  ],
+  concurrency: [
+    {
+      validator: (rule: FormItemRule, value: number) =>
+        Number.isInteger(value) && value >= 1 && value <= 100,
+      message: '并发数需为 1~100 的整数',
+      trigger: 'input',
+    },
+  ],
+};
+
+const submit = async () => {
+  const validated = await new Promise<boolean>((resolve) => {
+    formRef.value?.validate((errors) => {
+      if (errors) resolve(false);
+      else resolve(true);
+    });
+  });
+  if (!validated) return;
+
+  const { id, model, endpoint, key, concurrency } = formValue.value;
+  const worker = {
+    id: id.trim(),
+    model: model.trim(),
+    endpoint: endpoint.trim(),
+    key: key.trim(),
+    concurrency,
+  };
+
+  if (props.worker === undefined) {
+    workspace.addWorker(worker);
+  } else {
+    const index = workspaceRef.value.workers.findIndex(
+      (w) => w.id === props.worker?.id,
+    );
+    workspaceRef.value.workers[index] = worker;
+    emit('update:show', false);
+  }
+};
+
+const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
+</script>
+
+<template>
+  <c-modal
+    :show="show"
+    @update:show="$emit('update:show', $event)"
+    :title="verb + '翻译器'"
+  >
+    <n-form
+      ref="form"
+      :model="formValue"
+      :rules="formRules"
+      label-placement="left"
+      label-width="auto"
+    >
+      <n-form-item-row path="id" label="名字">
+        <n-input
+          v-model:value="formValue.id"
+          placeholder="给你的翻译器起个名字"
+        />
+      </n-form-item-row>
+      <n-form-item-row path="model" label="模型">
+        <n-input v-model:value="formValue.model" placeholder="deepseek-chat" />
+      </n-form-item-row>
+      <n-form-item-row path="endpoint" label="链接">
+        <n-input
+          v-model:value="formValue.endpoint"
+          placeholder="https://api.deepseek.com"
+        />
+      </n-form-item-row>
+      <n-form-item-row path="key" label="Key">
+        <n-input v-model:value="formValue.key" placeholder="API Key" />
+      </n-form-item-row>
+      <n-form-item-row path="concurrency" label="并发数">
+        <n-input-number
+          v-model:value="formValue.concurrency"
+          :min="1"
+          :max="10"
+        />
+      </n-form-item-row>
+    </n-form>
+    <template #action>
+      <c-button :label="verb" type="primary" @action="submit" />
+    </template>
+  </c-modal>
+</template>

--- a/web/src/pages/workspace/components/PipelineTaskCard.vue
+++ b/web/src/pages/workspace/components/PipelineTaskCard.vue
@@ -1,0 +1,349 @@
+<script lang="ts" setup>
+import {
+  ChevronRightOutlined,
+  KeyboardDoubleArrowUpOutlined,
+  KeyboardDoubleArrowDownOutlined,
+  RefreshOutlined,
+  DeleteOutlineOutlined,
+} from '@vicons/material';
+import type { ChapterMeta } from '@/domain/translator/TaskState';
+import { TaskState, ChapterSegmentState } from '@/domain/translator/TaskState';
+import type { TranslateJob, TranslateJobRecord } from '@/model/Translator';
+import { TranslateTaskDescriptor } from '@/model/Translator';
+import { createTranslationTask } from '@/domain/translator/TranslationTask/createTranslationTask';
+import type { TranslationTask } from '@/domain/translator/TranslationTask/types';
+
+const props = defineProps<{
+  job: TranslateJob;
+  taskStates: Map<string, TaskState>;
+  executingTasks: Set<string>;
+}>();
+
+const emit = defineEmits<{
+  delete: [task: string];
+  top: [task: string];
+  bottom: [task: string];
+}>();
+
+const jobRecord = computed(() => props.job as TranslateJobRecord);
+async function getOrLoadChapters(taskDesc: string): Promise<ChapterMeta[]> {
+  const state = props.taskStates.get(taskDesc);
+  if (state?.chapters.length) return state.chapters;
+  const task = createTask(taskDesc);
+  await task.initMeta();
+  const chapters = task.chapters;
+  if (state) state.chapters = chapters;
+  return chapters;
+}
+
+function getOrCreateTaskState(taskDesc: string): TaskState {
+  let state = props.taskStates.get(taskDesc);
+  if (!state) {
+    state = reactive(new TaskState(taskDesc)) as TaskState;
+    props.taskStates.set(taskDesc, state);
+  }
+  return state;
+}
+
+function updateJobProgress(job: TranslateJobRecord, chapters: ChapterMeta[]) {
+  const doneCount = chapters.filter((c) => c.status === 'done').length;
+  job.progress = { finished: doneCount, error: 0, total: chapters.length };
+  if (doneCount === chapters.length) {
+    job.finishAt = Date.now();
+  }
+}
+
+const expanded = ref(false);
+
+const toggleExpand = async () => {
+  if (expanded.value) {
+    expanded.value = false;
+    return;
+  }
+
+  const state = getOrCreateTaskState(props.job.task);
+  if (state.chapters.length === 0) {
+    const chapters = await getOrLoadChapters(props.job.task);
+    if (jobRecord.value.finishAt) {
+      state.chapters = chapters.map((c) => ({ ...c, status: 'done' as const }));
+    } else {
+      updateJobProgress(jobRecord.value, chapters);
+    }
+  }
+  expanded.value = true;
+};
+
+const themeVars = useThemeVars();
+
+const taskDesc = () => props.job.task;
+
+function getTaskStatus(): 'done' | 'pending' {
+  return props.job.finishAt ? 'done' : 'pending';
+}
+
+function retryAllFailed() {
+  const state = props.taskStates.get(props.job.task);
+  if (!state) return;
+  for (const ch of state.chapters) {
+    if (ch.status === 'error') {
+      ch.status = 'pending';
+      state.chapterStates.delete(ch.chapterId);
+    }
+  }
+  delete props.job.finishAt;
+}
+
+function hasFailedChapters(): boolean {
+  return (
+    props.taskStates
+      .get(taskDesc())
+      ?.chapters.some((c) => c.status === 'error') ?? false
+  );
+}
+
+const chapters = computed(() => {
+  const state = props.taskStates.get(props.job.task);
+  return (state?.chapters ?? []).map((ch) => {
+    const chState = state?.chapterStates.get(ch.chapterId);
+    const liveProgress = chState?.ready
+      ? { completed: chState.completedCount, total: chState.segments.length }
+      : undefined;
+    return {
+      ...ch,
+      status: ch.status,
+      segmentProgress: liveProgress ?? ch.segmentProgress,
+    };
+  });
+});
+
+const message = useMessage();
+
+function createTask(taskDesc: string): TranslationTask {
+  const { desc, params } = TranslateTaskDescriptor.parse(taskDesc);
+  return createTranslationTask(desc, 'gpt', params);
+}
+
+const showPreview = ref(false);
+const previewData = ref<{
+  title: string;
+  chapterState: ChapterSegmentState | null;
+} | null>(null);
+const loadingChapterId = ref<string | null>(null);
+
+const openPreview = async (chapterId: string) => {
+  loadingChapterId.value = chapterId;
+  try {
+    const chapters = await getOrLoadChapters(props.job.task);
+    const meta = chapters.find((c) => c.chapterId === chapterId);
+    const title = meta?.title ?? chapterId;
+
+    // 创建独立的 Task 实例用于预览（不使用缓存，避免 worker 的 AbortSignal 污染）
+    const previewTask = createTask(props.job.task);
+    await previewTask.initMeta();
+
+    const detail = await previewTask.fetchChapter(chapterId);
+
+    const state = props.taskStates.get(props.job.task);
+    const chapterState = state?.chapterStates.get(chapterId);
+
+    let chapterStateForPreview: ChapterSegmentState | null = null;
+    if (chapterState?.ready) {
+      chapterStateForPreview = chapterState;
+    } else if (state?.getChapterStatus(chapterId) === 'done') {
+      const tlParagraphs = detail.oldParagraphZh;
+      if (tlParagraphs?.length) {
+        const loadedState = new ChapterSegmentState(chapterId);
+        loadedState.injectDoneTranslation(detail.paragraphs, tlParagraphs);
+        chapterStateForPreview = loadedState;
+      }
+    } else {
+      chapterStateForPreview = chapterState ?? null;
+    }
+
+    previewData.value = { title, chapterState: chapterStateForPreview };
+    showPreview.value = true;
+  } catch (e) {
+    console.error('加载预览失败', e);
+    message.error('加载预览失败');
+  } finally {
+    loadingChapterId.value = null;
+  }
+};
+
+const closePreview = () => {
+  showPreview.value = false;
+  // 延迟清除数据，让 modal 关闭动画完成后再释放内容
+  setTimeout(() => {
+    if (!showPreview.value) {
+      previewData.value = null;
+    }
+  }, 200);
+};
+</script>
+
+<template>
+  <n-card
+    size="small"
+    :hoverable="true"
+    :class="{ 'task-card--expanded': expanded }"
+    :header-style="{
+      cursor: 'pointer',
+      padding: '10px 14px',
+      'user-select': 'none',
+    }"
+    :content-style="
+      expanded ? { padding: '0 14px 10px 14px' } : { padding: '0' }
+    "
+  >
+    <template #header>
+      <div @click="toggleExpand">
+        <n-flex align="center" :wrap="false" style="flex: 1; min-width: 0">
+          <div style="flex: 1; min-width: 0">
+            <div class="task-name">{{ job.description }}</div>
+            <job-task-link :task="job.task" class="task-link" />
+          </div>
+          <n-flex :size="8" align="center" :wrap="false" style="flex-shrink: 0">
+            <n-tag v-if="executingTasks.has(job.task)" size="tiny" type="info">
+              翻译中
+            </n-tag>
+            <n-tag
+              v-else-if="getTaskStatus() === 'done'"
+              size="tiny"
+              type="success"
+            >
+              已完成
+            </n-tag>
+            <n-tag v-else size="tiny" type="default">等待中</n-tag>
+            <span class="task-progress">
+              {{ jobRecord.progress?.finished ?? 0 }}/{{
+                jobRecord.progress?.total ??
+                taskStates.get(job.task)?.chapters.length ??
+                0
+              }}
+            </span>
+          </n-flex>
+
+          <n-flex :size="4" :wrap="false" style="flex-shrink: 0">
+            <n-tooltip trigger="hover">
+              <template #trigger>
+                <n-button
+                  size="tiny"
+                  circle
+                  quaternary
+                  @click.stop="emit('top', job.task)"
+                >
+                  <template #icon>
+                    <n-icon :component="KeyboardDoubleArrowUpOutlined" />
+                  </template>
+                </n-button>
+              </template>
+              置顶
+            </n-tooltip>
+            <n-tooltip trigger="hover">
+              <template #trigger>
+                <n-button
+                  size="tiny"
+                  circle
+                  quaternary
+                  @click.stop="emit('bottom', job.task)"
+                >
+                  <template #icon>
+                    <n-icon :component="KeyboardDoubleArrowDownOutlined" />
+                  </template>
+                </n-button>
+              </template>
+              置底
+            </n-tooltip>
+            <n-tooltip v-if="hasFailedChapters()" trigger="hover">
+              <template #trigger>
+                <n-button
+                  size="tiny"
+                  circle
+                  quaternary
+                  type="warning"
+                  @click.stop="retryAllFailed()"
+                >
+                  <template #icon>
+                    <n-icon :component="RefreshOutlined" />
+                  </template>
+                </n-button>
+              </template>
+              重试失败
+            </n-tooltip>
+            <n-tooltip trigger="hover">
+              <template #trigger>
+                <n-button
+                  size="tiny"
+                  circle
+                  quaternary
+                  type="error"
+                  @click.stop="emit('delete', job.task)"
+                >
+                  <template #icon>
+                    <n-icon :component="DeleteOutlineOutlined" />
+                  </template>
+                </n-button>
+              </template>
+              删除
+            </n-tooltip>
+          </n-flex>
+
+          <n-icon
+            :component="ChevronRightOutlined"
+            :class="['expand-arrow', { 'expand-arrow--rotated': expanded }]"
+          />
+        </n-flex>
+      </div>
+    </template>
+
+    <div v-if="expanded && chapters.length">
+      <chapter-grid
+        :chapters="chapters"
+        @preview="(cid: string) => openPreview(cid)"
+      />
+    </div>
+  </n-card>
+
+  <chapter-preview-modal
+    :show="showPreview"
+    :title="previewData?.title ?? ''"
+    :chapter-state="previewData?.chapterState ?? null"
+    @update:show="
+      (v: boolean) => {
+        if (!v) closePreview();
+      }
+    "
+  />
+</template>
+
+<style scoped>
+.task-card--expanded {
+  --n-border-color: v-bind('themeVars.primaryColorHover');
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+}
+.task-name {
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.task-link {
+  font-size: 11px;
+  line-height: 1.2;
+}
+.task-progress {
+  font-size: 12px;
+  color: v-bind('themeVars.textColor3');
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.expand-arrow {
+  font-size: 14px;
+  color: v-bind('themeVars.textColor3');
+  margin-left: 2px;
+  transition: transform 0.2s ease;
+}
+.expand-arrow--rotated {
+  transform: rotate(90deg);
+}
+</style>

--- a/web/src/pages/workspace/components/PipelineWorkerCard.vue
+++ b/web/src/pages/workspace/components/PipelineWorkerCard.vue
@@ -1,0 +1,165 @@
+<script lang="ts" setup>
+import {
+  DeleteOutlineOutlined,
+  DragIndicatorOutlined,
+  FlashOnOutlined,
+  PlayArrowOutlined,
+  SettingsOutlined,
+  StopOutlined,
+} from '@vicons/material';
+import { OpenAiTranslator } from '@auto-novel/translator';
+import type { GptPipelineWorker } from '@/model/Translator';
+
+const props = defineProps<{
+  worker: GptPipelineWorker;
+  running: boolean;
+  concurrency: { current: number; max: number };
+  errorCount: number;
+}>();
+
+const emit = defineEmits<{
+  start: [workerId: string];
+  stop: [workerId: string];
+  delete: [workerId: string];
+}>();
+
+const themeVars = useThemeVars();
+const message = useMessage();
+
+const showEditModal = ref(false);
+
+function isWorkerActive(): boolean {
+  return props.concurrency.current > 0;
+}
+
+const testWorker = async () => {
+  const textJp = [
+    '国境の長いトンネルを抜けると雪国であった。夜の底が白くなった。信号所に汽車が止まった。',
+  ];
+  try {
+    const translator = new OpenAiTranslator({
+      endpoint: props.worker.endpoint,
+      key: props.worker.key,
+      model: props.worker.model,
+    });
+    const textZh = await translator.translate(
+      textJp,
+      undefined,
+      new AbortController().signal,
+    );
+    message.success(`原文：${textJp[0]}\n译文：${textZh.join('')}`);
+  } catch (e: unknown) {
+    message.error(`翻译器错误：${e}`);
+  }
+};
+</script>
+
+<template>
+  <n-thing content-indented>
+    <template #avatar>
+      <n-icon
+        class="drag-trigger"
+        :size="18"
+        :depth="2"
+        :component="DragIndicatorOutlined"
+        style="cursor: move"
+      />
+    </template>
+
+    <template #header>
+      {{ worker.id }}
+      <n-text depth="3" style="font-size: 12px; padding-left: 2px">
+        {{ worker.model }}[{{ worker.key.slice(-4) }}]@{{ worker.endpoint }}
+      </n-text>
+      <span class="viz-translator" style="margin-left: 6px">
+        <n-text depth="3" class="viz-concurrency-num">
+          {{ concurrency.current }} / {{ concurrency.max }}
+        </n-text>
+        <span class="viz-status-dot" :class="{ active: isWorkerActive() }" />
+        <n-tag
+          v-if="errorCount"
+          size="tiny"
+          type="error"
+          :bordered="false"
+          class="viz-error-tag"
+        >
+          ✕ {{ errorCount }}
+        </n-tag>
+      </span>
+    </template>
+    <template #header-extra>
+      <n-flex :size="6" :wrap="false">
+        <c-button
+          v-if="running"
+          label="停止"
+          :icon="StopOutlined"
+          size="tiny"
+          secondary
+          @action="emit('stop', worker.id)"
+        />
+        <c-button
+          v-else
+          label="启动"
+          :icon="PlayArrowOutlined"
+          size="tiny"
+          secondary
+          @action="emit('start', worker.id)"
+        />
+        <c-icon-button
+          tooltip="测试"
+          :icon="FlashOnOutlined"
+          @action="testWorker"
+        />
+        <c-icon-button
+          :tooltip="running ? '请先停止翻译器后再修改' : '设置'"
+          :icon="SettingsOutlined"
+          :disabled="running"
+          @action="showEditModal = true"
+        />
+        <c-icon-button
+          :tooltip="running ? '请先停止翻译器后再删除' : '删除'"
+          :icon="DeleteOutlineOutlined"
+          type="error"
+          :disabled="running"
+          @action="emit('delete', worker.id)"
+        />
+      </n-flex>
+    </template>
+  </n-thing>
+
+  <gpt-pipeline-worker-modal
+    v-model:show="showEditModal"
+    :worker="showEditModal ? worker : undefined"
+  />
+</template>
+
+<style scoped>
+.viz-translator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.viz-concurrency-num {
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.viz-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: v-bind('themeVars.textColor3');
+  transition:
+    background 0.3s ease,
+    box-shadow 0.3s ease;
+}
+.viz-status-dot.active {
+  background: v-bind('themeVars.successColor');
+  box-shadow: 0 0 6px
+    color-mix(in srgb, v-bind('themeVars.successColor'), transparent);
+}
+.viz-error-tag {
+  margin-left: 4px;
+  font-variant-numeric: tabular-nums;
+}
+</style>


### PR DESCRIPTION
支持并发、章节状态追踪的工作区（目前与GPT工作区共用任务）。
在合并 #373 后合并。

总页面（硬编码章节请求的滑动窗口=3，后续可以适当增加自定义）和章节详情页面（可以看报错）：
<table>
  <tr>
    <td width="50%" valign="top">
      <img src="https://github.com/user-attachments/assets/23cc0b86-70ef-4b2b-b132-e3b956a82a38" width="100%" />
    </td>
    <td width="25%" valign="top">
      <img src="https://github.com/user-attachments/assets/f2aab113-d307-454c-b8a9-5182d6c00a3e" width="100%" />
    </td>
    <td width="25%" valign="top">
      <img src="https://github.com/user-attachments/assets/43f2aa40-86e6-422e-8370-a66c9d7eb6c5" width="100%" />
    </td>
  </tr>
  <tr>
    <td colspan="3"><br/></td>
  </tr>
  <tr>
    <td width="50%" colspan="1">
      <img src="https://github.com/user-attachments/assets/786a8cb5-e79c-4fe6-a548-7565e4f04210" width="100%" />
    </td>
    <td width="50%" colspan="2">
      <img src="https://github.com/user-attachments/assets/ce0f9285-8119-493c-ab4f-d9ec45b937de" width="100%" />
    </td>
  </tr>
</table>
