### PR TITLE
fix(web): 修复pipeline工作区任务乱序以及多个翻译器任务分配的问题

### DIFF
--- a/packages/translator/src/pipeline/translation_pipeline.ts
+++ b/packages/translator/src/pipeline/translation_pipeline.ts
@@ -109,7 +109,7 @@ export class TranslationPipeline {
     }
 
     await this.waitUntilBelowHighWaterMark(signal);
-    this.queue.enqueueAll(segments);
+    await this.queue.enqueueAll(segments);
     const results = await Promise.allSettled(segmentPromises);
 
     if (signal?.aborted) {
@@ -157,54 +157,57 @@ export class TranslationPipeline {
     tracker?: TranslatorTracker,
   ): Promise<void> {
     const semaphore = new Semaphore(loop.concurrency ?? 1);
-    const updateConcurrency = () => {
-      tracker?.onConcurrencyChange?.(semaphore.current, semaphore.max);
+    let activeCount = 0;
+    const updateConcurrency = (delta: number) => {
+      activeCount = activeCount + delta;
+      tracker?.onConcurrencyChange?.(activeCount, semaphore.max);
     };
+
+    const processSegment = async (segment: Segment) => {
+      // 命中缓存
+      if (this.cache) {
+        const cached = await this.cache.get(segment);
+        if (cached) {
+          segment.onComplete(segment, cached);
+          return;
+        }
+      }
+      // 旧译文未过期
+      if (segment.context?.expired === false && segment.context?.history) {
+        segment.onComplete(segment, segment.context.history.translatedLines);
+        return;
+      }
+      if (loop.abortController.signal.aborted) return;
+      segment.onStart(segment, loop.id);
+      updateConcurrency(1);
+      const translatedLines = await loop.translator.translate(
+        segment.lines,
+        segment.context,
+        loop.abortController.signal,
+      );
+      if (this.cache) {
+        await this.cache.set(segment, translatedLines);
+      }
+      segment.onComplete(segment, translatedLines);
+    };
+
     while (!loop.abortController.signal.aborted) {
+      await semaphore.acquire();
       try {
         const segment = await this.queue.dequeue(loop.abortController.signal);
-
-        // 命中缓存
-        if (this.cache) {
-          const cached = await this.cache.get(segment);
-          if (cached) {
-            segment.onComplete(segment, cached);
-            continue;
-          }
-        }
-
-        // 旧译文未过期
-        if (segment.context?.expired === false && segment.context?.history) {
-          segment.onComplete(segment, segment.context.history.translatedLines);
-          continue;
-        }
-
-        semaphore
-          .use(async () => {
-            updateConcurrency();
-            if (loop.abortController.signal.aborted) return;
-            try {
-              segment.onStart(segment, loop.id);
-              const translatedLines = await loop.translator.translate(
-                segment.lines,
-                segment.context,
-                loop.abortController.signal,
-              );
-              // 写入缓存
-              if (this.cache) {
-                await this.cache.set(segment, translatedLines);
-              }
-
-              segment.onComplete(segment, translatedLines);
-            } catch (err: any) {
-              if (err.name === 'AbortError') return;
+        processSegment(segment)
+          .catch((err: any) => {
+            if (err.name !== 'AbortError') {
               segment.onError(segment, err);
             }
           })
-          .then(() => {
-            updateConcurrency();
+          .finally(() => {
+            semaphore.release();
+            updateConcurrency(-1);
           });
-      } catch (err) {
+      } catch (err: any) {
+        semaphore.release();
+        updateConcurrency(-1);
         if (loop.abortController.signal.aborted) break;
       }
     }

--- a/packages/translator/src/pipeline/translation_pipeline.ts
+++ b/packages/translator/src/pipeline/translation_pipeline.ts
@@ -179,7 +179,6 @@ export class TranslationPipeline {
       }
       if (loop.abortController.signal.aborted) return;
       segment.onStart(segment, loop.id);
-      updateConcurrency(1);
       const translatedLines = await loop.translator.translate(
         segment.lines,
         segment.context,
@@ -195,6 +194,7 @@ export class TranslationPipeline {
       await semaphore.acquire();
       try {
         const segment = await this.queue.dequeue(loop.abortController.signal);
+        updateConcurrency(1);
         processSegment(segment)
           .catch((err: any) => {
             if (err.name !== 'AbortError') {

--- a/packages/translator/src/pipeline/translation_pipeline.ts
+++ b/packages/translator/src/pipeline/translation_pipeline.ts
@@ -193,21 +193,23 @@ export class TranslationPipeline {
     while (!loop.abortController.signal.aborted) {
       await semaphore.acquire();
       try {
-        const segment = await this.queue.dequeue(loop.abortController.signal);
-        updateConcurrency(1);
-        processSegment(segment)
-          .catch((err: any) => {
-            if (err.name !== 'AbortError') {
-              segment.onError(segment, err);
-            }
-          })
-          .finally(() => {
-            semaphore.release();
-            updateConcurrency(-1);
+        await this.queue
+          .dequeue(loop.abortController.signal)
+          .then((segment) => {
+            updateConcurrency(1);
+            processSegment(segment)
+              .catch((err: any) => {
+                if (err.name !== 'AbortError') {
+                  segment.onError(segment, err);
+                }
+              })
+              .finally(() => {
+                semaphore.release();
+                updateConcurrency(-1);
+              });
           });
       } catch (err: any) {
         semaphore.release();
-        updateConcurrency(-1);
         if (loop.abortController.signal.aborted) break;
       }
     }

--- a/packages/translator/src/segment/segment_queue.ts
+++ b/packages/translator/src/segment/segment_queue.ts
@@ -1,4 +1,5 @@
 import type { Segment, SegmentQueue } from '@/types';
+import { Semaphore } from '@/utils';
 
 export class DefaultSegmentQueue implements SegmentQueue {
   private readonly _items: Segment[] = [];
@@ -9,6 +10,8 @@ export class DefaultSegmentQueue implements SegmentQueue {
 
   /** 等待水位下降的生产者 resolve 回调 */
   private _hwResolver: (() => void) | null = null;
+  /** 入队锁，防止多任务 enqueueAll 交错 */
+  private readonly _enqueueLock = new Semaphore(1);
   private _hwPromise: Promise<void> | null = null;
 
   constructor(highWaterMark: number) {
@@ -23,7 +26,13 @@ export class DefaultSegmentQueue implements SegmentQueue {
     return this._highWaterMark;
   }
 
-  enqueueAll(segments: Segment[]): void {
+  async enqueueAll(segments: Segment[]): Promise<void> {
+    await this._enqueueLock.use(async () => {
+      this._enqueue(segments);
+    });
+  }
+
+  private _enqueue(segments: Segment[]): void {
     const segLen = segments.length;
     if (segLen === 0) return;
 

--- a/packages/translator/src/types.ts
+++ b/packages/translator/src/types.ts
@@ -58,7 +58,7 @@ export interface SegmentAssembler {
 export abstract class SegmentQueue {
   abstract readonly length: number;
   abstract readonly highWaterMark: number;
-  abstract enqueueAll(segments: Segment[]): void;
+  abstract enqueueAll(segments: Segment[]): Promise<void>;
   abstract dequeue(signal?: AbortSignal): Promise<Segment>;
   abstract waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void>;
 }

--- a/packages/translator/src/utils.ts
+++ b/packages/translator/src/utils.ts
@@ -96,7 +96,7 @@ export class Semaphore {
     return this._current;
   }
 
-  private async _acquire(): Promise<void> {
+  async acquire(): Promise<void> {
     if (this._current < this._max) {
       this._current++;
       return;
@@ -106,7 +106,7 @@ export class Semaphore {
     });
   }
 
-  private _release(): void {
+  release(): void {
     if (this.queue.length > 0) {
       const next = this.queue.shift()!;
       next();
@@ -127,12 +127,12 @@ export class Semaphore {
   }
 
   async use<T>(fn: () => Promise<T> | T): Promise<T> {
-    await this._acquire();
+    await this.acquire();
     let released = false;
     const safeRelease = () => {
       if (!released) {
         released = true;
-        this._release();
+        this.release();
       }
     };
     try {

--- a/web/src/domain/translator/TaskState.ts
+++ b/web/src/domain/translator/TaskState.ts
@@ -1,4 +1,3 @@
-import { reactive } from 'vue';
 import type { SegmentTracker, LineRange } from '@auto-novel/translator';
 
 export type ChapterStatus = 'pending' | 'translating' | 'done' | 'error';

--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -106,14 +106,15 @@ const GLOBAL_WINDOW = 3;
 function getNextJob(
   jobs: TranslateJob[],
   taskStatesMap: Map<string, TaskState>,
-): { job: TranslateJob; chapterId: string } | null {
+): { job: TranslateJob; chapterId: string; state: TaskState } | null {
   for (const job of jobs) {
     if (job.finishAt) continue;
     const state = taskStatesMap.get(job.task);
     if (!state) continue;
     for (const ch of state.chapters) {
       if (ch.status !== 'pending') continue;
-      return { job, chapterId: ch.chapterId };
+      ch.status = 'translating';
+      return { job, chapterId: ch.chapterId, state };
     }
   }
   return null;
@@ -148,14 +149,8 @@ function runProcessLoop(): Promise<void> | null {
       const item = getNextJob(jobs.value, taskStates.value);
       if (!item) break;
 
-      const { job, chapterId } = item;
+      const { job, chapterId, state } = item;
       executingTasks.add(job.task);
-
-      const state = taskStates.value.get(job.task);
-      if (!state) continue;
-
-      const ch = state.chapters.find((c) => c.chapterId === chapterId);
-      if (ch) ch.status = 'translating';
 
       const task = await getOrCreateTask(job.task);
       const executor = new TaskExecutor(task, pipeline);

--- a/web/src/pages/workspace/components/ChapterPreviewModal.vue
+++ b/web/src/pages/workspace/components/ChapterPreviewModal.vue
@@ -28,14 +28,13 @@ const previewState = computed(() => {
     }
   }
 
-  const errorMsgPrefix = seg?.translatorId ? `[${seg?.translatorId}] ` : '';
-  const rawError =
+  const errorMsg =
     seg && seg.status === 'error'
       ? state?.getSegmentError(selectedSegmentIndex.value)
       : undefined;
-  const errorMsg = rawError ? `${errorMsgPrefix}${rawError}`.trim() : undefined;
 
   return {
+    translatorId: seg?.translatorId,
     currentSegment: seg,
     previewParagraphs: paragraphs,
     currentSegmentError: errorMsg,
@@ -135,7 +134,9 @@ const onUpdateShow = (val: boolean) => {
         {{ i + 1 }}
       </n-button>
     </div>
-
+    <div class="preview-translator" v-if="previewState.translatorId">
+      翻译器：{{ previewState.translatorId }}
+    </div>
     <n-alert
       v-if="previewState.currentSegmentError"
       type="error"
@@ -200,6 +201,12 @@ const onUpdateShow = (val: boolean) => {
   .preview-zh {
     opacity: 1;
   }
+}
+
+.preview-translator {
+  font-size: 0.85em;
+  opacity: 0.6;
+  padding: 4px 2px;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
修复以下问题：

问题1：之前 TranslationPipeline.queue 的 enqueueAll 没有上锁，导致多个任务同时入队时，不同章节的分段混在一起。
问题2：之前 TranslationPipeline 中的翻译循环没有等待，导致翻译器实际上是”预分配“了所有分段再在并发限制下翻译，而不是”翻译完再请求分段“，导致并发多的翻译器提前结束任务。