### PR TITLE
feat(web): pipeline工作区根据高水位限制预加载待翻译章节

### DIFF
--- a/packages/translator/src/index.ts
+++ b/packages/translator/src/index.ts
@@ -1,5 +1,6 @@
 export { TranslationPipeline } from './pipeline/translation_pipeline';
 export { DefaultSegmentQueue } from './segment';
+export { Semaphore } from './utils';
 
 export type { Translator } from './types';
 export { createOpenAiApi, OpenAiError } from './translator/openai-api';

--- a/packages/translator/src/pipeline/translation_pipeline.ts
+++ b/packages/translator/src/pipeline/translation_pipeline.ts
@@ -19,7 +19,7 @@ import {
 import { Semaphore, randomUUID } from '@/utils';
 
 export class TranslationPipeline {
-  protected queue: SegmentQueue;
+  public queue: SegmentQueue;
   protected translatorLoops: Map<string, TranslationLoop>;
   public segmenter: LineSegmenter;
   private assembler: SegmentAssembler;
@@ -44,6 +44,27 @@ export class TranslationPipeline {
     signal?: AbortSignal,
     tracker?: SegmentTracker,
   ): Promise<string> {
+    const { segments, segmentPromises } = this.prepareSegments(
+      text,
+      glossary,
+      history,
+      signal,
+      tracker,
+    );
+    await this.queue.enqueueAll(segments, signal);
+    return this.resolveTranslation(segments, segmentPromises, signal, tracker);
+  }
+
+  prepareSegments(
+    text: string,
+    glossary?: Glossary,
+    history?: TranslationHistory,
+    signal?: AbortSignal,
+    tracker?: SegmentTracker,
+  ): {
+    segments: Segment[];
+    segmentPromises: Promise<{ order: number; text: string }>[];
+  } {
     signal?.throwIfAborted();
 
     const lines = text.split('\n');
@@ -108,8 +129,15 @@ export class TranslationPipeline {
       segmentPromises.push(promise);
     }
 
-    await this.waitUntilBelowHighWaterMark(signal);
-    await this.queue.enqueueAll(segments);
+    return { segments, segmentPromises };
+  }
+
+  async resolveTranslation(
+    segments: Segment[],
+    segmentPromises: Promise<{ order: number; text: string }>[],
+    signal?: AbortSignal,
+    tracker?: SegmentTracker,
+  ): Promise<string> {
     const results = await Promise.allSettled(segmentPromises);
 
     if (signal?.aborted) {
@@ -204,6 +232,7 @@ export class TranslationPipeline {
                 }
               })
               .finally(() => {
+                this.queue.ack();
                 semaphore.release();
                 updateConcurrency(-1);
               });

--- a/packages/translator/src/segment/segment_queue.ts
+++ b/packages/translator/src/segment/segment_queue.ts
@@ -4,15 +4,16 @@ import { Semaphore } from '@/utils';
 export class DefaultSegmentQueue implements SegmentQueue {
   private readonly _items: Segment[] = [];
   private readonly _highWaterMark: number;
+  /** 系统中所有在途（排队中+翻译中）的分片总数 */
+  private _enqueuedCount = 0;
 
   /** 等待出队的消费者 resolve 回调队列（FIFO） */
   private readonly _dequeueResolvers: Array<(seg: Segment) => void> = [];
 
-  /** 等待水位下降的生产者 resolve 回调 */
-  private _hwResolver: (() => void) | null = null;
+  /** 等待水位下降的生产者 resolve 回调队列（FIFO），每次只释放一个 */
+  private _hwResolvers: Array<() => void> = [];
   /** 入队锁，防止多任务 enqueueAll 交错 */
   private readonly _enqueueLock = new Semaphore(1);
-  private _hwPromise: Promise<void> | null = null;
 
   constructor(highWaterMark: number) {
     this._highWaterMark = Math.max(1, highWaterMark);
@@ -26,8 +27,9 @@ export class DefaultSegmentQueue implements SegmentQueue {
     return this._highWaterMark;
   }
 
-  async enqueueAll(segments: Segment[]): Promise<void> {
+  async enqueueAll(segments: Segment[], signal?: AbortSignal): Promise<void> {
     await this._enqueueLock.use(async () => {
+      await this.waitUntilBelowHighWaterMark(signal);
       this._enqueue(segments);
     });
   }
@@ -35,6 +37,7 @@ export class DefaultSegmentQueue implements SegmentQueue {
   private _enqueue(segments: Segment[]): void {
     const segLen = segments.length;
     if (segLen === 0) return;
+    this._enqueuedCount += segLen;
 
     const resolverLen = this._dequeueResolvers.length;
     const matchCount = Math.min(segLen, resolverLen);
@@ -57,7 +60,6 @@ export class DefaultSegmentQueue implements SegmentQueue {
 
     if (this._items.length > 0) {
       const item = this._items.shift()!;
-      this._tryResolveHw();
       return item;
     }
     return new Promise<Segment>((resolve, reject) => {
@@ -79,39 +81,35 @@ export class DefaultSegmentQueue implements SegmentQueue {
   async waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void> {
     signal?.throwIfAborted();
 
-    if (this._items.length < this._highWaterMark) return;
+    if (this._enqueuedCount < this._highWaterMark) return;
 
-    if (!this._hwPromise) {
-      this._hwPromise = new Promise<void>((resolve) => {
-        this._hwResolver = resolve;
-      });
-    }
+    return new Promise<void>((resolve, reject) => {
+      this._hwResolvers.push(resolve);
 
-    if (!signal) return this._hwPromise;
-
-    return new Promise((resolve, reject) => {
-      const onAbort = () => reject(signal.reason);
-      signal.addEventListener('abort', onAbort, { once: true });
-
-      this._hwPromise!.then(
-        () => {
-          signal.removeEventListener('abort', onAbort);
-          resolve();
-        },
-        (err) => {
-          signal.removeEventListener('abort', onAbort);
-          reject(err);
-        },
-      );
+      if (signal) {
+        const onAbort = () => {
+          const idx = this._hwResolvers.indexOf(resolve);
+          if (idx !== -1) this._hwResolvers.splice(idx, 1);
+          reject(signal.reason);
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
     });
   }
 
-  /** 检查并尝试唤醒等待水位下降的生产者 */
+  /** 消费者完成一个分片后调用，释放一个槽位 */
+  ack(): void {
+    this._enqueuedCount--;
+    this._tryResolveHw();
+  }
+
+  /** 检查并尝试唤醒一个等待水位下降的生产者 */
   private _tryResolveHw(): void {
-    if (this._hwResolver && this._items.length < this._highWaterMark) {
-      const resolve = this._hwResolver;
-      this._hwResolver = null;
-      this._hwPromise = null;
+    if (
+      this._hwResolvers.length > 0 &&
+      this._enqueuedCount < this._highWaterMark
+    ) {
+      const resolve = this._hwResolvers.shift()!;
       resolve();
     }
   }

--- a/packages/translator/src/types.ts
+++ b/packages/translator/src/types.ts
@@ -58,9 +58,10 @@ export interface SegmentAssembler {
 export abstract class SegmentQueue {
   abstract readonly length: number;
   abstract readonly highWaterMark: number;
-  abstract enqueueAll(segments: Segment[]): Promise<void>;
+  abstract enqueueAll(segments: Segment[], signal?: AbortSignal): Promise<void>;
   abstract dequeue(signal?: AbortSignal): Promise<Segment>;
   abstract waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void>;
+  abstract ack(): void;
 }
 
 export interface PromptBuilder {

--- a/packages/translator/src/utils.ts
+++ b/packages/translator/src/utils.ts
@@ -128,17 +128,10 @@ export class Semaphore {
 
   async use<T>(fn: () => Promise<T> | T): Promise<T> {
     await this.acquire();
-    let released = false;
-    const safeRelease = () => {
-      if (!released) {
-        released = true;
-        this.release();
-      }
-    };
     try {
       return await fn();
     } finally {
-      safeRelease();
+      this.release();
     }
   }
 }

--- a/web/src/domain/translator/TaskExecutor.ts
+++ b/web/src/domain/translator/TaskExecutor.ts
@@ -1,4 +1,4 @@
-import { TranslationPipeline } from '@auto-novel/translator';
+import { TranslationPipeline, Semaphore } from '@auto-novel/translator';
 import type { ChapterStatus, ChapterSegmentState } from './TaskState';
 import type { TranslationTask } from './TranslationTask/types';
 
@@ -13,6 +13,7 @@ export class TaskExecutor {
   constructor(
     private task: TranslationTask,
     private pipeline: TranslationPipeline,
+    private fetchSemaphore: Semaphore,
   ) {}
 
   /**
@@ -34,28 +35,39 @@ export class TaskExecutor {
     tracker.onLog(`[${chapter.title}] 开始获取原文`);
 
     try {
-      const detail = await this.task.fetchChapter(chapterId);
-      if (signal?.aborted) {
-        tracker.onChapterStatus(chapterId, 'pending');
-        return 'abort';
-      }
+      const fetchAndEnqueue = async () => {
+        await this.pipeline.waitUntilBelowHighWaterMark(signal);
+        const detail = await this.task.fetchChapter(chapterId);
 
-      tracker.onChapterStatus(chapterId, 'translating');
-      tracker.onLog(`[${chapter.title}] 开始翻译`);
+        const original = detail.paragraphs.join('\n');
+        const history =
+          this.task.level !== 'all' && detail.oldParagraphZh
+            ? {
+                lines: detail.paragraphs,
+                translatedLines: detail.oldParagraphZh,
+                glossary: detail.oldGlossary ?? {},
+              }
+            : undefined;
+        const { segments, segmentPromises } = this.pipeline.prepareSegments(
+          original,
+          detail.glossary,
+          history,
+          signal,
+          tracker.segmentTracker,
+        );
+        await this.pipeline.queue.enqueueAll(segments, signal);
+        tracker.onChapterStatus(chapterId, 'translating');
+        tracker.onLog(`[${chapter.title}] 开始翻译`);
 
-      const original = detail.paragraphs.join('\n');
-      const history =
-        this.task.level !== 'all' && detail.oldParagraphZh
-          ? {
-              lines: detail.paragraphs,
-              translatedLines: detail.oldParagraphZh,
-              glossary: detail.oldGlossary ?? {},
-            }
-          : undefined;
-      const translated = await this.pipeline.translate(
-        original,
-        detail.glossary,
-        history,
+        return { detail, segments, segmentPromises };
+      };
+      const { detail, segments, segmentPromises } = this.fetchSemaphore
+        ? await this.fetchSemaphore.use(fetchAndEnqueue)
+        : await fetchAndEnqueue();
+
+      const translated = await this.pipeline.resolveTranslation(
+        segments,
+        segmentPromises,
         signal,
         tracker.segmentTracker,
       );

--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -5,7 +5,11 @@ import {
   PlusOutlined,
 } from '@vicons/material';
 import { VueDraggable } from 'vue-draggable-plus';
-import { OpenAiTranslator, TranslationPipeline } from '@auto-novel/translator';
+import {
+  Semaphore,
+  OpenAiTranslator,
+  TranslationPipeline,
+} from '@auto-novel/translator';
 import type { TranslatorTracker } from '@auto-novel/translator';
 
 import { doAction } from '@/pages/util';
@@ -26,6 +30,19 @@ const jobs = computed(() => gptWorkspace.ref.value.jobs);
 
 const showWorkerModal = ref(false);
 const showLocalVolumeDrawer = ref(false);
+
+/** 同时处理的章节数上限 */
+const GLOBAL_WINDOW = 66;
+/** 同时 fetch 的章节数上限 */
+const FETCH_CONCURRENCY = 1;
+const fetchSemaphore = new Semaphore(FETCH_CONCURRENCY);
+/** pipeline 内同时翻译的分块的高水位标记 */
+const HIGH_WATER_MARK = 100;
+const pipeline = new TranslationPipeline(
+  HIGH_WATER_MARK,
+  undefined,
+  new IndexedDbSegmentCache('gpt-seg-cache'),
+);
 
 // ========== 任务状态管理 ==========
 
@@ -52,11 +69,6 @@ const workerErrors = computed(() => {
 });
 const executingTasks = reactive(new Set<string>());
 
-const pipeline = new TranslationPipeline(
-  100,
-  undefined,
-  new IndexedDbSegmentCache('gpt-seg-cache'),
-);
 let processLoopAbortController: AbortController | null = null;
 let processLoopPromise: Promise<void> | null = null;
 
@@ -97,11 +109,6 @@ async function getOrCreateTask(taskDesc: string): Promise<TranslationTask> {
   }
   return task;
 }
-
-// ========== 全局滑动窗口 ==========
-
-/** 同时处理的章节数 */
-const GLOBAL_WINDOW = 3;
 
 function getNextJob(
   jobs: TranslateJob[],
@@ -153,7 +160,7 @@ function runProcessLoop(): Promise<void> | null {
       executingTasks.add(job.task);
 
       const task = await getOrCreateTask(job.task);
-      const executor = new TaskExecutor(task, pipeline);
+      const executor = new TaskExecutor(task, pipeline, fetchSemaphore);
 
       const segmentTracker = state.getChapterState(chapterId);
       if (!segmentTracker) continue;

--- a/web/src/pages/workspace/components/ChapterGrid.vue
+++ b/web/src/pages/workspace/components/ChapterGrid.vue
@@ -19,8 +19,16 @@ const chapters = computed(() => {
     const liveProgress = chState?.ready
       ? { completed: chState.completedCount, total: chState.segments.length }
       : ch.segmentProgress;
+    let displayStatus = ch.status;
+    if (
+      displayStatus === 'translating' &&
+      (!chState?.ready || chState.translatingCount === 0)
+    ) {
+      displayStatus = 'pending';
+    }
     return {
       ...ch,
+      status: displayStatus,
       segmentProgress: liveProgress,
     } as ChapterMeta;
   });

--- a/web/src/pages/workspace/components/GptPipelineWorkerModal.vue
+++ b/web/src/pages/workspace/components/GptPipelineWorkerModal.vue
@@ -177,7 +177,7 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
         <n-input-number
           v-model:value="formValue.concurrency"
           :min="1"
-          :max="10"
+          :max="100"
         />
       </n-form-item-row>
     </n-form>


### PR DESCRIPTION
* 主要修复的问题：segment_queue.ts 之前水位是按内部队列来的，没有考虑到segment出队后到被完全处理才算作一次水位下降。
* 然后修复了问题：之前的 TaskExecutor 内的 fetch章节请求+入队的过程没有水位判断，导致会大量涌入。
* 更新下UI，因为状态为 translating 的章节的数量等于 GLOBAL_WINDOW，所以在显示时，只有内部确实有翻译的章节才会显示成翻译状态。

目前设置了三个参数来调节：
```
/** 同时处理的章节数上限 */
const GLOBAL_WINDOW = 66;

/** 同时 fetch 的章节数上限 */
const FETCH_CONCURRENCY = 1;

/** pipeline 内同时翻译的分块的高水位标记 */
const HIGH_WATER_MARK = 100;
```

以 HIGH_WATER_MARK 优先，其次是 GLOBAL_WINDOW。
FETCH_CONCURRENCY 只控制章节内容请求，目前不包含章节元数据的请求。