### PR TITLE
fix(web): 修复 GPT 工作区 BETA 重新排队后不翻译新增章节的问题

### DIFF
--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -50,6 +50,7 @@ const pipeline = new TranslationPipeline(
 
 const taskStates = ref(new Map<string, TaskState>());
 const taskCache = new Map<string, TranslationTask>();
+const taskVersions = ref(new Map<string, number>());
 
 interface WorkerState {
   running: boolean;
@@ -145,11 +146,21 @@ function countPendingChapters(
   return count;
 }
 
+function hasRunningWorker(): boolean {
+  return [...workerStates.value.values()].some((s) => s.running);
+}
+
+function clearTaskRuntimeState(task: string): void {
+  taskStates.value.delete(task);
+  taskCache.delete(task);
+  taskVersions.value.delete(task);
+}
+
 // ========== 全局处理循环 ==========
 
 function runProcessLoop(): Promise<void> | null {
   if (processLoopPromise) return processLoopPromise;
-  if ([...workerStates.value.values()].every((s) => !s.running)) {
+  if (!hasRunningWorker()) {
     return null;
   }
 
@@ -204,6 +215,9 @@ function runProcessLoop(): Promise<void> | null {
     }
     processLoopPromise = null;
     processLoopAbortController = null;
+    if (countPendingChapters(jobs.value, taskStates.value) > 0) {
+      runProcessLoop();
+    }
   });
 
   return processLoopPromise;
@@ -271,8 +285,7 @@ const deleteJob = (task: string) => {
     return;
   }
   gptWorkspace.deleteJob(task);
-  taskStates.value.delete(task);
-  taskCache.delete(task);
+  clearTaskRuntimeState(task);
 };
 
 const deleteAllJobs = () =>
@@ -301,15 +314,36 @@ const clearCache = () =>
 
 watch(
   () => [...jobs.value],
-  async (jobs) => {
+  async (workspaceJobs) => {
     const uninitialized: TranslateJob[] = [];
-    for (const job of jobs) {
-      if (taskStates.value.get(job.task)?.initialized) continue;
+    const activeTasks = new Set(workspaceJobs.map((job) => job.task));
+    for (const task of [...taskStates.value.keys()]) {
+      if (!activeTasks.has(task)) clearTaskRuntimeState(task);
+    }
+    for (const task of [...taskCache.keys()]) {
+      if (!activeTasks.has(task)) clearTaskRuntimeState(task);
+    }
+    for (const task of [...taskVersions.value.keys()]) {
+      if (!activeTasks.has(task)) clearTaskRuntimeState(task);
+    }
+
+    for (const job of workspaceJobs) {
+      if (taskVersions.value.get(job.task) !== job.createAt) {
+        clearTaskRuntimeState(job.task);
+      }
+      const state = taskStates.value.get(job.task);
+      if (
+        taskVersions.value.get(job.task) === job.createAt &&
+        state?.initialized
+      ) {
+        continue;
+      }
       if (job.finishAt) {
         taskStates.value.set(
           job.task,
           reactive(new TaskState(job.task)) as TaskState,
         );
+        taskVersions.value.set(job.task, job.createAt);
         continue;
       }
       uninitialized.push(job);
@@ -319,10 +353,13 @@ watch(
         try {
           const task = await getOrCreateTask(job.task);
           if (!task.initialized) await task.initMeta();
+          const currentJob = jobs.value.find((it) => it.task === job.task);
+          if (!currentJob || currentJob.createAt !== job.createAt) return;
           const chapters = task.chapters;
           const state = reactive(new TaskState(job.task)) as TaskState;
           state.initChapters(chapters);
           taskStates.value.set(job.task, state);
+          taskVersions.value.set(job.task, job.createAt);
           const doneCount = chapters.filter((c) => c.status === 'done').length;
           (job as TranslateJobRecord).progress = {
             finished: doneCount,
@@ -337,6 +374,7 @@ watch(
         }
       }),
     );
+    if (uninitialized.length > 0) runProcessLoop();
   },
   { immediate: true },
 );

--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -317,13 +317,12 @@ watch(
   async (workspaceJobs) => {
     const uninitialized: TranslateJob[] = [];
     const activeTasks = new Set(workspaceJobs.map((job) => job.task));
-    for (const task of [...taskStates.value.keys()]) {
-      if (!activeTasks.has(task)) clearTaskRuntimeState(task);
-    }
-    for (const task of [...taskCache.keys()]) {
-      if (!activeTasks.has(task)) clearTaskRuntimeState(task);
-    }
-    for (const task of [...taskVersions.value.keys()]) {
+    const knownTasks = new Set([
+      ...taskStates.value.keys(),
+      ...taskCache.keys(),
+      ...taskVersions.value.keys(),
+    ]);
+    for (const task of knownTasks) {
       if (!activeTasks.has(task)) clearTaskRuntimeState(task);
     }
 

--- a/web/src/pages/workspace/components/PipelineTaskCard.vue
+++ b/web/src/pages/workspace/components/PipelineTaskCard.vue
@@ -66,11 +66,14 @@ const toggleExpand = async () => {
 
   const state = getOrCreateTaskState();
   if (!state.initialized) {
+    const wasFinished = jobRecord.value.finishAt !== undefined;
     const chapters = await getChapterMetas();
     state.initChapters(chapters);
-    updateJobProgress(jobRecord.value, chapters);
-    if (chapters.some((ch) => ch.status === 'pending')) {
-      emit('retry', props.job.task);
+    if (!wasFinished) {
+      updateJobProgress(jobRecord.value, chapters);
+      if (chapters.some((ch) => ch.status === 'pending')) {
+        emit('retry', props.job.task);
+      }
     }
   }
   expanded.value = true;

--- a/web/src/pages/workspace/components/PipelineTaskCard.vue
+++ b/web/src/pages/workspace/components/PipelineTaskCard.vue
@@ -46,16 +46,6 @@ function getOrCreateTaskState(): TaskState {
   return reactive(new TaskState(props.job.task)) as TaskState;
 }
 
-function updateJobProgress(job: TranslateJobRecord, chapters: ChapterMeta[]) {
-  const doneCount = chapters.filter((c) => c.status === 'done').length;
-  job.progress = { finished: doneCount, error: 0, total: chapters.length };
-  if (doneCount === chapters.length) {
-    job.finishAt ??= Date.now();
-  } else {
-    delete job.finishAt;
-  }
-}
-
 const expanded = ref(false);
 
 const toggleExpand = async () => {
@@ -66,15 +56,8 @@ const toggleExpand = async () => {
 
   const state = getOrCreateTaskState();
   if (!state.initialized) {
-    const wasFinished = jobRecord.value.finishAt !== undefined;
     const chapters = await getChapterMetas();
     state.initChapters(chapters);
-    if (!wasFinished) {
-      updateJobProgress(jobRecord.value, chapters);
-      if (chapters.some((ch) => ch.status === 'pending')) {
-        emit('retry', props.job.task);
-      }
-    }
   }
   expanded.value = true;
 };

--- a/web/src/pages/workspace/components/PipelineTaskCard.vue
+++ b/web/src/pages/workspace/components/PipelineTaskCard.vue
@@ -50,7 +50,9 @@ function updateJobProgress(job: TranslateJobRecord, chapters: ChapterMeta[]) {
   const doneCount = chapters.filter((c) => c.status === 'done').length;
   job.progress = { finished: doneCount, error: 0, total: chapters.length };
   if (doneCount === chapters.length) {
-    job.finishAt = Date.now();
+    job.finishAt ??= Date.now();
+  } else {
+    delete job.finishAt;
   }
 }
 
@@ -65,12 +67,10 @@ const toggleExpand = async () => {
   const state = getOrCreateTaskState();
   if (!state.initialized) {
     const chapters = await getChapterMetas();
-    if (jobRecord.value.finishAt) {
-      state.initChapters(
-        chapters.map((c) => ({ ...c, status: 'done' as const })),
-      );
-    } else {
-      updateJobProgress(jobRecord.value, chapters);
+    state.initChapters(chapters);
+    updateJobProgress(jobRecord.value, chapters);
+    if (chapters.some((ch) => ch.status === 'pending')) {
+      emit('retry', props.job.task);
     }
   }
   expanded.value = true;

--- a/web/src/stores/useWorkspaceStore.ts
+++ b/web/src/stores/useWorkspaceStore.ts
@@ -8,6 +8,7 @@ import { TranslateJob } from '@/model/Translator';
 import { lazy, useLocalStorage } from '@/util';
 
 import { LSKey } from './key';
+import { addWorkspaceJob } from './workspaceJob';
 
 interface Workspace<T> {
   workers: T[];
@@ -39,13 +40,7 @@ const createWorkspaceStore = <W extends GptWorker | SakuraWorker>(
   };
 
   const addJob = (job: TranslateJob) => {
-    const conflictJob = ref.value.jobs.find((it) => it.task === job.task);
-    if (conflictJob !== undefined) {
-      return false;
-    } else {
-      ref.value.jobs.push(job);
-      return true;
-    }
+    return addWorkspaceJob(ref.value.jobs, job);
   };
   const deleteJob = (task: string) => {
     ref.value.jobs = ref.value.jobs.filter((j) => j.task !== task);

--- a/web/src/stores/workspaceJob.ts
+++ b/web/src/stores/workspaceJob.ts
@@ -1,0 +1,21 @@
+import type { TranslateJob } from '@/model/Translator';
+
+export const addWorkspaceJob = (jobs: TranslateJob[], job: TranslateJob) => {
+  const conflictJobIndex = jobs.findIndex((it) => it.task === job.task);
+  if (conflictJobIndex === -1) {
+    jobs.push(job);
+    return true;
+  }
+
+  const conflictJob = jobs[conflictJobIndex];
+  if (conflictJob.finishAt === undefined) {
+    return false;
+  }
+
+  jobs[conflictJobIndex] = {
+    task: job.task,
+    description: job.description,
+    createAt: job.createAt,
+  };
+  return true;
+};

--- a/web/tests/workspaceJob.test.ts
+++ b/web/tests/workspaceJob.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TranslateJob, TranslateJobRecord } from '../src/model/Translator';
+import { addWorkspaceJob } from '../src/stores/workspaceJob';
+
+describe('addWorkspaceJob', () => {
+  it('adds a new job when no task conflicts', () => {
+    const jobs: TranslateJob[] = [];
+    const job: TranslateJob = {
+      task: 'web/provider/novel?level=normal',
+      description: 'Novel',
+      createAt: 1,
+    };
+
+    expect(addWorkspaceJob(jobs, job)).toBe(true);
+    expect(jobs).toEqual([job]);
+  });
+
+  it('rejects a duplicate unfinished job', () => {
+    const jobs: TranslateJob[] = [
+      {
+        task: 'web/provider/novel?level=normal',
+        description: 'Existing',
+        createAt: 1,
+      },
+    ];
+
+    const duplicate: TranslateJob = {
+      task: 'web/provider/novel?level=normal',
+      description: 'Duplicate',
+      createAt: 2,
+    };
+
+    expect(addWorkspaceJob(jobs, duplicate)).toBe(false);
+    expect(jobs).toEqual([
+      {
+        task: 'web/provider/novel?level=normal',
+        description: 'Existing',
+        createAt: 1,
+      },
+    ]);
+  });
+
+  it('requeues a duplicate finished job as a fresh job', () => {
+    const jobs: TranslateJobRecord[] = [
+      {
+        task: 'web/provider/novel?level=normal',
+        description: 'Existing',
+        createAt: 1,
+        finishAt: 10,
+        progress: { finished: 3, error: 0, total: 3 },
+      },
+    ];
+
+    const duplicate: TranslateJob = {
+      task: 'web/provider/novel?level=normal',
+      description: 'Updated',
+      createAt: 2,
+    };
+
+    expect(addWorkspaceJob(jobs, duplicate)).toBe(true);
+    expect(jobs).toEqual([
+      {
+        task: 'web/provider/novel?level=normal',
+        description: 'Updated',
+        createAt: 2,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## 问题背景

一本小说在 GPT 工作区 BETA 翻译完成后会保留在任务队列中。小说有更新后再次点击“排队 GPT”，会提示“翻译任务已经存在”。即使在工作区点击开始翻译，也不会翻译新增章节。

需要手动删除任务后再次点击“排队 GPT”。

原因是已完成任务仍占用同一个任务描述，同时 BETA 工作区会复用旧的任务状态和章节缓存，导致新增章节没有被重新发现和调度。

旧版 GPT 工作区完成后会从队列删除任务，所以没有这个问题。

## 修改内容

- 允许已完成的同一翻译任务重新排队，重新排队时会替换旧的完成任务状态。
- GPT 工作区 BETA 在任务重新入队后会清理旧的运行时状态和章节缓存，重新拉取最新章节信息。
- 修复已完成任务展开后发现新增章节时不会自动启动翻译的问题。
- 增加工作区任务重新入队逻辑的单元测试。

## 验证

在 `web/` 目录下执行：

- `pnpm test`：通过，10 个测试全部通过
- `pnpm build`：通过，包含 `vite build` 和 `vue-tsc -b --noEmit`