### PR TITLE
fix(web): 修复收藏、未收藏按钮点击后，UI 状态未更新的问题

### DIFF
--- a/web/src/pages/novel/WenkuNovel.vue
+++ b/web/src/pages/novel/WenkuNovel.vue
@@ -145,7 +145,7 @@ function sortJpVolumes(volumeJp: VolumeJpDto[]) {
         </router-link>
 
         <favorite-button
-          v-model:favored="novel.favored"
+          :favored="novel.favored"
           :novel="{ type: 'wenku', novelId }"
         />
 

--- a/web/src/pages/novel/components/FavoriteButton.vue
+++ b/web/src/pages/novel/components/FavoriteButton.vue
@@ -3,7 +3,6 @@ import { FavoriteBorderOutlined, FavoriteOutlined } from '@vicons/material';
 
 import { doAction } from '@/pages/util';
 import { FavoredRepo } from '@/stores';
-import { useQueryCache } from '@pinia/colada';
 
 const props = defineProps<{
   favored: string | undefined;
@@ -22,20 +21,10 @@ const favoredTitle = computed(
   () => favoreds.value.find((it) => it.id === props.favored)?.title,
 );
 
-const queryCache = useQueryCache();
-const queryKey = computed(() => {
-  if (props.novel.type === 'web') {
-    return ['web-novel', props.novel.providerId, props.novel.novelId];
-  } else {
-    return ['wenku-novel', props.novel.novelId];
-  }
-});
-
 const favoriteNovel = (favoredId: string) =>
   doAction(
-    FavoredRepo.favoriteNovel(favoredId, props.novel).then(async () => {
+    FavoredRepo.favoriteNovel(favoredId, props.novel).then(() => {
       showFavoredModal.value = false;
-      await queryCache.invalidateQueries({ key: queryKey.value });
     }),
     '收藏',
     message,
@@ -44,9 +33,8 @@ const favoriteNovel = (favoredId: string) =>
 const unfavoriteNovel = async () => {
   if (props.favored === undefined) return;
   await doAction(
-    FavoredRepo.unfavoriteNovel(props.favored, props.novel).then(async () => {
+    FavoredRepo.unfavoriteNovel(props.favored, props.novel).then(() => {
       showFavoredModal.value = false;
-      await queryCache.invalidateQueries({ key: queryKey.value });
     }),
     '取消收藏',
     message,

--- a/web/src/pages/novel/components/FavoriteButton.vue
+++ b/web/src/pages/novel/components/FavoriteButton.vue
@@ -3,15 +3,13 @@ import { FavoriteBorderOutlined, FavoriteOutlined } from '@vicons/material';
 
 import { doAction } from '@/pages/util';
 import { FavoredRepo } from '@/stores';
+import { useQueryCache } from '@pinia/colada';
 
 const props = defineProps<{
   favored: string | undefined;
   novel:
     | { type: 'web'; providerId: string; novelId: string }
     | { type: 'wenku'; novelId: string };
-}>();
-const emit = defineEmits<{
-  'update:favored': [string | undefined];
 }>();
 
 const message = useMessage();
@@ -24,11 +22,20 @@ const favoredTitle = computed(
   () => favoreds.value.find((it) => it.id === props.favored)?.title,
 );
 
+const queryCache = useQueryCache();
+const queryKey = computed(() => {
+  if (props.novel.type === 'web') {
+    return ['web-novel', props.novel.providerId, props.novel.novelId];
+  } else {
+    return ['wenku-novel', props.novel.novelId];
+  }
+});
+
 const favoriteNovel = (favoredId: string) =>
   doAction(
-    FavoredRepo.favoriteNovel(favoredId, props.novel).then(() => {
-      emit('update:favored', favoredId);
+    FavoredRepo.favoriteNovel(favoredId, props.novel).then(async () => {
       showFavoredModal.value = false;
+      await queryCache.invalidateQueries({ key: queryKey.value });
     }),
     '收藏',
     message,
@@ -37,9 +44,9 @@ const favoriteNovel = (favoredId: string) =>
 const unfavoriteNovel = async () => {
   if (props.favored === undefined) return;
   await doAction(
-    FavoredRepo.unfavoriteNovel(props.favored, props.novel).then(() => {
-      emit('update:favored', undefined);
+    FavoredRepo.unfavoriteNovel(props.favored, props.novel).then(async () => {
       showFavoredModal.value = false;
+      await queryCache.invalidateQueries({ key: queryKey.value });
     }),
     '取消收藏',
     message,

--- a/web/src/pages/novel/components/WebNovelActions.vue
+++ b/web/src/pages/novel/components/WebNovelActions.vue
@@ -47,7 +47,7 @@ const startReadChapter = computed(() => {
     <c-button v-else label="开始阅读" :round="false" disabled />
 
     <FavoriteButton
-      v-model:favored="novel.favored"
+      :favored="novel.favored"
       :novel="{ type: 'web', providerId, novelId }"
     />
 

--- a/web/src/stores/useFavored.ts
+++ b/web/src/stores/useFavored.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@pinia/colada';
+import { useQuery, useQueryCache } from '@pinia/colada';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { Favored } from '@/api';
@@ -96,14 +96,23 @@ const favoriteNovel = async (
     | { type: 'web'; providerId: string; novelId: string }
     | { type: 'wenku'; novelId: string },
 ) => {
+  const queryCache = useQueryCache();
   if (novel.type === 'web') {
     await FavoredApi.favoriteWebNovel(
       favoredId,
       novel.providerId,
       novel.novelId,
     );
+    await queryCache.invalidateQueries({
+      key: ['web-novel', novel.providerId, novel.novelId],
+      exact: true,
+    });
   } else if (novel.type === 'wenku') {
     await FavoredApi.favoriteWenkuNovel(favoredId, novel.novelId);
+    await queryCache.invalidateQueries({
+      key: ['wenku-novel', novel.novelId],
+      exact: true,
+    });
   } else {
     novel satisfies never;
   }
@@ -115,14 +124,23 @@ const unfavoriteNovel = async (
     | { type: 'web'; providerId: string; novelId: string }
     | { type: 'wenku'; novelId: string },
 ) => {
+  const queryCache = useQueryCache();
   if (novel.type === 'web') {
     await FavoredApi.unfavoriteWebNovel(
       favoredId,
       novel.providerId,
       novel.novelId,
     );
+    await queryCache.invalidateQueries({
+      key: ['web-novel', novel.providerId, novel.novelId],
+      exact: true,
+    });
   } else if (novel.type === 'wenku') {
     await FavoredApi.unfavoriteWenkuNovel(favoredId, novel.novelId);
+    await queryCache.invalidateQueries({
+      key: ['wenku-novel', novel.novelId],
+      exact: true,
+    });
   } else {
     novel satisfies never;
   }


### PR DESCRIPTION
问题如图：
<img width="760" height="433" alt="image" src="https://github.com/user-attachments/assets/9bc1153e-3015-4169-aae8-5d71af36c9c1" />

点击收藏后，由于收藏状态是使用 useQuery 获取后通过 props 层层传递下来的，所以内部使用 emit 修改父组件的状态并没什么用。

这里使用 invalidateQueries 来无效数据缓存，使源头重新获取数据后，所有子组件就能同步新的状态。