### PR TITLE
fix(web): 修复windows环境下命令行解析错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "packageManager": "pnpm@10.33.4",
   "scripts": {
     "build": "pnpm --stream -r run build",
-    "dev:web": "pnpm --stream --filter '@auto-novel/web^...' run build && pnpm --stream --parallel --filter '@auto-novel/web' --filter '@auto-novel/web^...' run dev"
+    "dev:web": "pnpm --stream --filter \"@auto-novel/web^...\" run build && pnpm --stream --parallel --filter \"@auto-novel/web...\" run dev"
   }
 }


### PR DESCRIPTION
适配windows环境的启动命令
- 用双引号包裹
- 简化后半部分的filter参数

--filter <package_name>^...
只选择依赖包

--filter <package_name>...
选择自身与其依赖