### PR TITLE
fix(web): 修复阅读器中切换颜色预设时，颜色选择器不更新的问题

### DIFF
--- a/web/src/pages/reader/components/ReaderSettingModal.vue
+++ b/web/src/pages/reader/components/ReaderSettingModal.vue
@@ -10,10 +10,6 @@ const isWideScreen = useIsWideScreen(600);
 const readerSettingStore = useReaderSettingStore();
 const { readerSetting } = storeToRefs(readerSettingStore);
 
-const setCustomBodyColor = (color: string) =>
-  (readerSetting.value.theme.bodyColor = color);
-const setCustomFontColor = (color: string) =>
-  (readerSetting.value.theme.fontColor = color);
 const setIndentSize = (diff: number) => {
   readerSetting.value.indentSize = Math.min(
     Math.max(readerSetting.value.indentSize! + diff, 0),
@@ -221,8 +217,7 @@ const setIndentSize = (diff: number) => {
                   <n-color-picker
                     :modes="['hex']"
                     :show-alpha="false"
-                    :default-value="readerSetting.theme.bodyColor"
-                    :on-complete="setCustomBodyColor"
+                    v-model:value="readerSetting.theme.bodyColor"
                     style="width: 8.2em"
                   >
                     <template #label="color">背景：{{ color }}</template>
@@ -230,8 +225,7 @@ const setIndentSize = (diff: number) => {
                   <n-color-picker
                     :modes="['hex']"
                     :show-alpha="false"
-                    :default-value="readerSetting.theme.fontColor"
-                    :on-complete="setCustomFontColor"
+                    v-model:value="readerSetting.theme.fontColor"
                     style="width: 8.2em"
                   >
                     <template #label="color">文字：{{ color }}</template>


### PR DESCRIPTION
## Issue

`ReaderSettingModal.vue` 中的背景和文字颜色选择器 (`n-color-picker`) 在切换颜色预设或从自定义颜色切换到预设颜色后，显示的色号不会更新，刷新后才会更新。

## Changes

将颜色选择器改为受控的 `v-model:value`。
