### PR TITLE
fix(web): 修复工作区添加翻译器的modal不自动关闭的问题

### DIFF
--- a/web/src/pages/workspace/components/GptPipelineWorkerModal.vue
+++ b/web/src/pages/workspace/components/GptPipelineWorkerModal.vue
@@ -130,6 +130,7 @@ const submit = async () => {
 
   if (props.worker === undefined) {
     workspace.addWorker(worker);
+    emit('update:show', false);
   } else {
     const index = workspaceRef.value.workers.findIndex(
       (w) => w.id === props.worker?.id,

--- a/web/src/pages/workspace/components/GptWorkerModal.vue
+++ b/web/src/pages/workspace/components/GptWorkerModal.vue
@@ -109,6 +109,7 @@ const submit = async () => {
 
   if (props.worker === undefined) {
     workspace.addWorker(worker);
+    emit('update:show', false);
   } else {
     const index = workspaceRef.value.workers.findIndex(
       ({ id }) => id === props.worker?.id,

--- a/web/src/pages/workspace/components/SakuraWorkerModal.vue
+++ b/web/src/pages/workspace/components/SakuraWorkerModal.vue
@@ -83,6 +83,7 @@ const submit = async () => {
 
   if (props.worker === undefined) {
     workspace.addWorker(worker);
+    emit('update:show', false);
   } else {
     const index = workspaceRef.value.workers.findIndex(
       ({ id }) => id === props.worker?.id,


### PR DESCRIPTION
## 问题

如题所示

## 修复

和关闭modal一样补上 `emit('update:show', false);`