### PR TITLE
fix(server): 修复部分章节错乱的问题

### DIFF
--- a/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
@@ -563,10 +563,13 @@ private fun simpleMergeToc(
 ): List<WebNovelTocItem> {
     return remoteToc.map { itemNew ->
         val itemOld = localToc.find { it.titleJp == itemNew.titleJp }
-        if (itemOld?.titleZh == null) {
+        if (itemOld == null) {
             itemNew
         } else {
-            itemNew.copy(titleZh = itemOld.titleZh)
+            itemNew.copy(
+                chapterId = itemOld.chapterId ?: itemNew.chapterId,
+                titleZh = itemOld.titleZh ?: itemNew.titleZh,
+            )
         }
     }
 }
@@ -585,7 +588,10 @@ private fun mergeUpdatedToc(
             ?.let(localByChapterId::get)
             ?: localByTitle[remoteItem.titleJp]
         if (localItem != null && localItem.titleJp == remoteItem.titleJp) {
-            remoteItem.copy(titleZh = localItem.titleZh)
+            remoteItem.copy(
+                chapterId = localItem.chapterId ?: remoteItem.chapterId,
+                titleZh = localItem.titleZh ?: remoteItem.titleZh,
+            )
         } else {
             remoteItem
         }


### PR DESCRIPTION
hamlen部分小说由多个大章节组成，目前前面的大章节增加小章节后，翻译时会导致章节原文混乱。